### PR TITLE
feat(mcp): MCP Gateway Phase 2 — composition, discovery, and management

### DIFF
--- a/prompts/agent.system.tool.mcp_discover.md
+++ b/prompts/agent.system.tool.mcp_discover.md
@@ -1,0 +1,31 @@
+### mcp_discover:
+Search MCP Registry for servers, list available tools, or search tools across mounted servers.
+Actions: "search" (find servers by keyword), "list" (show all mounted tools), "search_tools" (find tools by keyword)
+**Example usage**:
+
+~~~json
+{
+    "thoughts": [
+        "I need to find an MCP server for GitHub integration",
+    ],
+    "headline": "Searching MCP Registry for GitHub servers",
+    "tool_name": "mcp_discover",
+    "tool_args": {
+        "action": "search",
+        "query": "github"
+    }
+}
+~~~
+
+~~~json
+{
+    "thoughts": [
+        "Let me check what tools are available from mounted MCP servers",
+    ],
+    "headline": "Listing available MCP tools",
+    "tool_name": "mcp_discover",
+    "tool_args": {
+        "action": "list"
+    }
+}
+~~~

--- a/python/api/mcp_gateway_catalog.py
+++ b/python/api/mcp_gateway_catalog.py
@@ -1,0 +1,87 @@
+"""MCP Gateway Docker Catalog API — browse and install from Docker MCP Catalog.
+
+Supports YAML import of Docker MCP Catalog entries and
+conversion to gateway-managed McpServerResource objects.
+"""
+
+import json
+import logging
+from typing import Any
+
+import yaml
+
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers.docker_mcp_catalog import (
+    catalog_entry_to_resource,
+    parse_catalog_entries,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def handle_browse(catalog_yaml: str) -> dict[str, Any]:
+    """Parse YAML content and return browsable catalog entries."""
+    try:
+        data = yaml.safe_load(catalog_yaml)
+    except yaml.YAMLError as exc:
+        return {"ok": False, "error": f"Invalid YAML: {exc}"}
+
+    if isinstance(data, dict):
+        entries = data.get("servers", [])
+    elif isinstance(data, list):
+        entries = data
+    else:
+        return {"ok": False, "error": "Expected YAML with 'servers' list or array"}
+
+    parsed = parse_catalog_entries(entries)
+    return {"ok": True, "data": parsed}
+
+
+def handle_install(
+    store,
+    user_id: str,
+    entry: dict[str, Any],
+) -> dict[str, Any]:
+    """Install a Docker catalog entry as a McpServerResource."""
+    if not entry.get("name"):
+        return {"ok": False, "error": "Missing required field: name"}
+
+    resource = catalog_entry_to_resource(entry, user_id=user_id)
+    store.upsert(resource)
+
+    from python.api.mcp_gateway_servers import resource_to_dict
+
+    return {"ok": True, "data": resource_to_dict(resource)}
+
+
+class McpGatewayCatalog(ApiHandler):
+    """API for browsing and installing from Docker MCP Catalog."""
+
+    @classmethod
+    def get_required_permission(cls) -> tuple[str, str] | None:
+        return None
+
+    async def process(
+        self, input: dict[Any, Any], request: Request
+    ) -> dict[Any, Any] | Response:
+        action = input.get("action", "browse")
+        user_id = self._get_user_id() or "anonymous"
+
+        if action == "browse":
+            catalog_yaml = input.get("yaml", "")
+            if not catalog_yaml:
+                return {"ok": False, "error": "Missing required field: yaml"}
+            return handle_browse(catalog_yaml)
+
+        elif action == "install":
+            from python.api.mcp_gateway_servers import get_store
+
+            store = get_store()
+            entry = input.get("entry", {})
+            return handle_install(store=store, user_id=user_id, entry=entry)
+
+        return Response(
+            json.dumps({"error": f"Unknown action: {action}"}),
+            status=400,
+            mimetype="application/json",
+        )

--- a/python/api/mcp_gateway_discover.py
+++ b/python/api/mcp_gateway_discover.py
@@ -1,0 +1,128 @@
+"""MCP Gateway discovery API — search and install from MCP Registry.
+
+Proxies to McpRegistryClient for server discovery and converts
+registry entries into McpServerResource objects for installation.
+"""
+
+import json
+import logging
+from typing import Any
+
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers.mcp_registry_client import McpRegistryClient
+from python.helpers.mcp_resource_store import (
+    InMemoryMcpResourceStore,
+    McpServerResource,
+)
+
+logger = logging.getLogger(__name__)
+
+# Module-level singleton
+_registry_client: McpRegistryClient | None = None
+
+
+def _get_registry_client() -> McpRegistryClient:
+    global _registry_client
+    if _registry_client is None:
+        _registry_client = McpRegistryClient()
+    return _registry_client
+
+
+async def handle_search(
+    query: str = "",
+    limit: int = 20,
+) -> dict[str, Any]:
+    """Search the MCP Registry for servers."""
+    try:
+        client = _get_registry_client()
+        results = await client.search(query, limit=limit)
+        return {"ok": True, "data": results}
+    except Exception as exc:
+        logger.warning("Registry search failed: %s", exc)
+        return {"ok": False, "error": str(exc)}
+
+
+async def handle_install(
+    store: InMemoryMcpResourceStore,
+    user_id: str,
+    server_data: dict[str, Any],
+) -> dict[str, Any]:
+    """Convert a registry entry to a McpServerResource and add to store."""
+    name = server_data.get("name")
+    if not name:
+        return {"ok": False, "error": "Missing required field: name"}
+
+    packages = server_data.get("packages", [])
+
+    # Infer transport and command from package info
+    transport_type = "streamable_http"
+    command = ""
+    args: list[str] = []
+    docker_image = ""
+
+    if packages:
+        pkg = packages[0]
+        registry = pkg.get("registry_name", "")
+        pkg_name = pkg.get("name", "")
+        pkg_version = pkg.get("version", "")
+
+        if registry == "npm":
+            transport_type = "stdio"
+            command = "npx"
+            version_suffix = f"@{pkg_version}" if pkg_version else ""
+            args = ["-y", f"{pkg_name}{version_suffix}"]
+        elif registry in ("pip", "pypi"):
+            transport_type = "stdio"
+            command = "uvx"
+            args = [pkg_name]
+        elif registry == "docker":
+            docker_image = f"{pkg_name}:{pkg_version}" if pkg_version else pkg_name
+
+    resource = McpServerResource(
+        name=name,
+        transport_type=transport_type,
+        created_by=user_id,
+        command=command,
+        args=args,
+        docker_image=docker_image or None,
+        is_enabled=True,
+    )
+    store.upsert(resource)
+
+    from python.api.mcp_gateway_servers import resource_to_dict
+
+    return {"ok": True, "data": resource_to_dict(resource)}
+
+
+class McpGatewayDiscover(ApiHandler):
+    """Discovery API for browsing and installing from MCP Registry."""
+
+    @classmethod
+    def get_required_permission(cls) -> tuple[str, str] | None:
+        return None
+
+    async def process(
+        self, input: dict[Any, Any], request: Request
+    ) -> dict[Any, Any] | Response:
+        action = input.get("action", "search")
+        user_id = self._get_user_id() or "anonymous"
+
+        if action == "search":
+            query = input.get("query", "")
+            limit = input.get("limit", 20)
+            return await handle_search(query=query, limit=limit)
+
+        elif action == "install":
+            from python.api.mcp_gateway_servers import get_store
+
+            store = get_store()
+            server_data = input.get("server", input)
+            return await handle_install(
+                store=store, user_id=user_id, server_data=server_data
+            )
+
+        return Response(
+            json.dumps({"error": f"Unknown action: {action}"}),
+            status=400,
+            mimetype="application/json",
+        )

--- a/python/api/mcp_gateway_pool.py
+++ b/python/api/mcp_gateway_pool.py
@@ -1,0 +1,101 @@
+"""MCP Gateway connection pool status and health API.
+
+Exposes pool diagnostics: status, health_check, and evict operations.
+"""
+
+import json
+from typing import Any
+
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers.mcp_connection_pool import McpConnectionPool
+
+# Module-level pool singleton
+_pool = McpConnectionPool(max_connections=20)
+
+
+def get_pool() -> McpConnectionPool:
+    """Return the module-level connection pool singleton."""
+    return _pool
+
+
+def handle_status(pool: McpConnectionPool) -> dict[str, Any]:
+    """Return pool status with active count and connection details."""
+    connections = []
+    for name, pooled in pool._connections.items():
+        connections.append(
+            {
+                "server_name": pooled.server_name,
+                "in_use": pooled.in_use,
+                "last_used_at": pooled.last_used_at,
+                "created_at": pooled.created_at,
+            }
+        )
+
+    return {
+        "ok": True,
+        "data": {
+            "active_count": pool.active_count,
+            "max_connections": pool.max_connections,
+            "connections": connections,
+        },
+    }
+
+
+async def handle_health_check(pool: McpConnectionPool) -> dict[str, Any]:
+    """Trigger health check and return results."""
+    before = pool.active_count
+    await pool.health_check()
+    after = pool.active_count
+    evicted = before - after
+
+    return {
+        "ok": True,
+        "data": {
+            "checked": before,
+            "evicted": evicted,
+            "remaining": after,
+        },
+    }
+
+
+async def handle_evict(pool: McpConnectionPool, name: str) -> dict[str, Any]:
+    """Evict a specific connection by server name."""
+    await pool.evict(name)
+    return {"ok": True}
+
+
+class McpGatewayPool(ApiHandler):
+    """Connection pool status and health API handler."""
+
+    @classmethod
+    def get_required_permission(cls) -> tuple[str, str] | None:
+        # Dynamic: status uses read, health_check/evict use write
+        return None
+
+    async def process(
+        self, input: dict[Any, Any], request: Request
+    ) -> dict[Any, Any] | Response:
+        action = input.get("action", "status")
+        pool = get_pool()
+
+        if action == "status":
+            return handle_status(pool)
+
+        elif action == "health_check":
+            return await handle_health_check(pool)
+
+        elif action == "evict":
+            name = input.get("name", "")
+            if not name:
+                return Response(
+                    json.dumps({"error": "Missing required field: name"}),
+                    status=400,
+                    mimetype="application/json",
+                )
+            return await handle_evict(pool, name=name)
+
+        return Response(
+            json.dumps({"error": f"Unknown action: {action}"}),
+            status=400,
+            mimetype="application/json",
+        )

--- a/python/api/mcp_gateway_servers.py
+++ b/python/api/mcp_gateway_servers.py
@@ -1,0 +1,216 @@
+"""MCP Gateway server management API with CRUD and RBAC.
+
+Manages McpServerResource objects through the InMemoryMcpResourceStore.
+Follows the action-based dispatch pattern from mcp_services.py.
+"""
+
+import json
+from typing import Any
+
+from python.helpers.api import ApiHandler, Request, Response
+from python.helpers.mcp_resource_store import (
+    InMemoryMcpResourceStore,
+    McpServerResource,
+)
+
+# Module-level store singleton
+_store = InMemoryMcpResourceStore()
+
+
+def get_store() -> InMemoryMcpResourceStore:
+    """Return the module-level resource store singleton."""
+    return _store
+
+
+def resource_to_dict(r: McpServerResource) -> dict[str, Any]:
+    """Serialize a McpServerResource to a JSON-friendly dict."""
+    return {
+        "name": r.name,
+        "transport_type": r.transport_type,
+        "created_by": r.created_by,
+        "url": r.url,
+        "command": r.command,
+        "args": r.args,
+        "env": r.env,
+        "docker_image": r.docker_image,
+        "docker_ports": r.docker_ports,
+        "required_roles": r.required_roles,
+        "is_enabled": r.is_enabled,
+        "created_at": r.created_at,
+        "updated_at": r.updated_at,
+    }
+
+
+def handle_list(
+    store: InMemoryMcpResourceStore,
+    user_id: str,
+    roles: list[str],
+) -> dict[str, Any]:
+    """List all resources accessible to the given user."""
+    all_resources = store.list_all()
+    accessible = [
+        resource_to_dict(r)
+        for r in all_resources
+        if r.can_access(user_id, roles=roles, operation="read")
+    ]
+    return {"ok": True, "data": accessible}
+
+
+def handle_create(
+    store: InMemoryMcpResourceStore,
+    user_id: str,
+    data: dict[str, Any],
+) -> dict[str, Any]:
+    """Create a new McpServerResource in the store."""
+    name = data.get("name")
+    transport_type = data.get("transport_type")
+
+    if not name:
+        return {"ok": False, "error": "Missing required field: name"}
+    if not transport_type:
+        return {"ok": False, "error": "Missing required field: transport_type"}
+
+    resource = McpServerResource(
+        name=name,
+        transport_type=transport_type,
+        created_by=user_id,
+        url=data.get("url"),
+        command=data.get("command"),
+        args=data.get("args", []),
+        env=data.get("env", {}),
+        docker_image=data.get("docker_image"),
+        docker_ports=data.get("docker_ports", {}),
+        required_roles=data.get("required_roles", []),
+        is_enabled=data.get("is_enabled", True),
+    )
+    store.upsert(resource)
+    return {"ok": True, "data": resource_to_dict(resource)}
+
+
+def handle_update(
+    store: InMemoryMcpResourceStore,
+    user_id: str,
+    roles: list[str],
+    data: dict[str, Any],
+) -> dict[str, Any]:
+    """Update an existing McpServerResource."""
+    name = data.get("name")
+    if not name:
+        return {"ok": False, "error": "Missing required field: name"}
+
+    existing = store.get(name)
+    if existing is None:
+        return {"ok": False, "error": f"Resource not found: {name}"}
+
+    if not existing.can_access(user_id, roles=roles, operation="write"):
+        return {"ok": False, "error": "Forbidden: insufficient permissions"}
+
+    # Merge updatable fields
+    updatable = (
+        "url",
+        "command",
+        "args",
+        "env",
+        "docker_image",
+        "docker_ports",
+        "required_roles",
+        "is_enabled",
+        "transport_type",
+    )
+    for field in updatable:
+        if field in data:
+            setattr(existing, field, data[field])
+
+    store.upsert(existing)
+    return {"ok": True, "data": resource_to_dict(existing)}
+
+
+def handle_delete(
+    store: InMemoryMcpResourceStore,
+    user_id: str,
+    roles: list[str],
+    name: str,
+) -> dict[str, Any]:
+    """Delete a McpServerResource from the store."""
+    existing = store.get(name)
+    if existing is None:
+        return {"ok": False, "error": f"Resource not found: {name}"}
+
+    if not existing.can_access(user_id, roles=roles, operation="write"):
+        return {"ok": False, "error": "Forbidden: insufficient permissions"}
+
+    store.delete(name)
+    return {"ok": True}
+
+
+def handle_status(
+    store: InMemoryMcpResourceStore,
+    name: str,
+    container_manager: Any = None,
+) -> dict[str, Any]:
+    """Get status for a gateway server."""
+    existing = store.get(name)
+    if existing is None:
+        return {"ok": False, "error": f"Resource not found: {name}"}
+
+    result: dict[str, Any] = {
+        "name": existing.name,
+        "transport_type": existing.transport_type,
+        "is_enabled": existing.is_enabled,
+    }
+
+    # Include container status if manager is available
+    if container_manager is not None:
+        result["container"] = container_manager.get_status(name)
+    else:
+        result["container"] = {"running": False, "status": "no_manager"}
+
+    return {"ok": True, "data": result}
+
+
+class McpGatewayServers(ApiHandler):
+    """CRUD API for MCP gateway server resources."""
+
+    @classmethod
+    def get_required_permission(cls) -> tuple[str, str] | None:
+        # Dynamic: read is filtered by can_access, write checked in handlers
+        return None
+
+    async def process(
+        self, input: dict[Any, Any], request: Request
+    ) -> dict[Any, Any] | Response:
+        action = input.get("action", "list")
+        user_id = self._get_user_id() or "anonymous"
+        store = get_store()
+
+        # Determine user roles from session
+        try:
+            from flask import g
+
+            user = g.current_user if hasattr(g, "current_user") else None
+            roles = user.get("roles", []) if user else []
+        except RuntimeError:
+            roles = []
+
+        if action == "list":
+            return handle_list(store, user_id=user_id, roles=roles)
+
+        elif action == "create":
+            return handle_create(store, user_id=user_id, data=input)
+
+        elif action == "update":
+            return handle_update(store, user_id=user_id, roles=roles, data=input)
+
+        elif action == "delete":
+            name = input.get("name", "")
+            return handle_delete(store, user_id=user_id, roles=roles, name=name)
+
+        elif action == "status":
+            name = input.get("name", "")
+            return handle_status(store, name=name)
+
+        return Response(
+            json.dumps({"error": f"Unknown action: {action}"}),
+            status=400,
+            mimetype="application/json",
+        )

--- a/python/helpers/docker_mcp_catalog.py
+++ b/python/helpers/docker_mcp_catalog.py
@@ -1,0 +1,72 @@
+"""Docker MCP Catalog client for browsing and installing catalog servers.
+
+Supports parsing Docker MCP Catalog entries (from YAML export or API)
+and converting them to McpServerResource objects for the gateway store.
+
+Usage:
+    docker mcp catalog show docker-mcp > catalog.yaml
+    # Then import via API or load programmatically
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from python.helpers.mcp_resource_store import McpServerResource
+
+logger = logging.getLogger(__name__)
+
+
+def parse_catalog_entries(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Parse and validate a list of Docker MCP Catalog entries.
+
+    Accepts raw catalog data (from YAML parse or API response).
+    Skips entries missing the required 'name' field.
+    """
+    results = []
+    for entry in entries:
+        name = entry.get("name")
+        if not name:
+            logger.debug("Skipping catalog entry without name: %s", entry)
+            continue
+
+        parsed: dict[str, Any] = {
+            "name": name,
+            "description": entry.get("description", ""),
+            "image": entry.get("image", ""),
+            "transport": entry.get("transport", "streamable_http"),
+        }
+        if "port" in entry:
+            parsed["port"] = entry["port"]
+        if "env" in entry:
+            parsed["env"] = entry["env"]
+        if "args" in entry:
+            parsed["args"] = entry["args"]
+
+        results.append(parsed)
+
+    return results
+
+
+def catalog_entry_to_resource(
+    entry: dict[str, Any],
+    user_id: str = "system",
+) -> McpServerResource:
+    """Convert a parsed catalog entry to a McpServerResource."""
+    transport = entry.get("transport", "streamable_http")
+    port = entry.get("port")
+    docker_ports = {}
+    if port:
+        docker_ports = {f"{port}/tcp": port}
+
+    return McpServerResource(
+        name=entry["name"],
+        transport_type=transport,
+        created_by=user_id,
+        docker_image=entry.get("image"),
+        docker_ports=docker_ports,
+        env=entry.get("env", {}),
+        args=entry.get("args", []),
+        is_enabled=True,
+    )

--- a/python/helpers/docker_mcp_catalog.py
+++ b/python/helpers/docker_mcp_catalog.py
@@ -28,7 +28,7 @@ def parse_catalog_entries(entries: list[dict[str, Any]]) -> list[dict[str, Any]]
     for entry in entries:
         name = entry.get("name")
         if not name:
-            logger.debug("Skipping catalog entry without name: %s", entry)
+            logger.debug("Skipping catalog entry without name")
             continue
 
         parsed: dict[str, Any] = {

--- a/python/helpers/mcp_gateway_compositor.py
+++ b/python/helpers/mcp_gateway_compositor.py
@@ -1,0 +1,161 @@
+"""Gateway compositor for FastMCP multi-server mounting.
+
+Composes registered MCP servers onto a main FastMCP instance using
+create_proxy() and mount(). Each server gets its own namespace prefix.
+
+Unmount uses providers.pop() as the maintainer-endorsed workaround
+(no unmount() API exists — confirmed GitHub issue #2154).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from fastmcp import FastMCP
+from fastmcp.server import create_proxy
+
+from python.helpers.mcp_resource_store import McpServerResource
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _MountEntry:
+    """Tracks a mounted provider's position and state."""
+
+    name: str
+    provider_index: int
+    disabled: bool = False
+
+
+class McpGatewayCompositor:
+    """Composes registered MCP servers onto the main FastMCP instance."""
+
+    def __init__(self, mcp_server: FastMCP) -> None:
+        self._server = mcp_server
+        self._mounts: dict[str, _MountEntry] = {}
+
+    @property
+    def mounted_names(self) -> set[str]:
+        """Return the set of currently mounted server names."""
+        return set(self._mounts.keys())
+
+    def is_disabled(self, name: str) -> bool:
+        """Check if a mounted server is currently disabled."""
+        entry = self._mounts.get(name)
+        return entry.disabled if entry else False
+
+    async def mount_server(self, resource: McpServerResource) -> None:
+        """Mount a registered server onto the main FastMCP instance."""
+        if not resource.is_enabled:
+            logger.debug("Skipping disabled resource: %s", resource.name)
+            return
+
+        if resource.name in self._mounts:
+            raise ValueError(
+                f"Server '{resource.name}' is already mounted. "
+                "Unmount it first to re-mount."
+            )
+
+        proxy = self._create_proxy(resource)
+        if proxy is None:
+            return
+
+        self._server.mount(proxy, namespace=resource.name)
+        # Track the provider index (last added)
+        idx = len(self._server.providers) - 1
+        self._mounts[resource.name] = _MountEntry(
+            name=resource.name, provider_index=idx
+        )
+        logger.info(
+            "Mounted MCP server '%s' at namespace '%s'", resource.name, resource.name
+        )
+
+    async def unmount_server(self, name: str) -> None:
+        """Remove a mounted server using providers.pop() workaround.
+
+        IMPORTANT: FastMCP has NO unmount() API (confirmed GitHub issue #2154).
+        The maintainer-endorsed approach is providers.pop(index).
+        """
+        entry = self._mounts.pop(name, None)
+        if entry is None:
+            return
+
+        idx = entry.provider_index
+        if idx < len(self._server.providers):
+            self._server.providers.pop(idx)
+            # Re-index remaining tracked mounts
+            for e in self._mounts.values():
+                if e.provider_index > idx:
+                    e.provider_index -= 1
+            logger.info("Unmounted MCP server '%s'", name)
+        else:
+            logger.warning(
+                "Provider index %d out of range for '%s' — may already be removed",
+                idx,
+                name,
+            )
+
+    async def disable_server(self, name: str) -> None:
+        """Temporarily hide a server's components without unmounting."""
+        entry = self._mounts.get(name)
+        if entry is None:
+            return
+
+        idx = entry.provider_index
+        if idx < len(self._server.providers):
+            self._server.providers[idx].disable()
+            entry.disabled = True
+            logger.info("Disabled MCP server '%s'", name)
+
+    async def enable_server(self, name: str) -> None:
+        """Restore a disabled server's component visibility."""
+        entry = self._mounts.get(name)
+        if entry is None:
+            return
+
+        idx = entry.provider_index
+        if idx < len(self._server.providers):
+            self._server.providers[idx].enable()
+            entry.disabled = False
+            logger.info("Enabled MCP server '%s'", name)
+
+    def _create_proxy(self, resource: McpServerResource) -> FastMCP | None:
+        """Create a FastMCP proxy for the given resource.
+
+        Returns None if the resource doesn't have valid config for its type.
+        """
+        if resource.transport_type in ("streamable_http", "sse"):
+            if not resource.url:
+                logger.warning(
+                    "HTTP resource '%s' has no URL — skipping", resource.name
+                )
+                return None
+            return create_proxy(resource.url)
+
+        if resource.transport_type == "stdio":
+            if not resource.command:
+                logger.warning(
+                    "Stdio resource '%s' has no command — skipping", resource.name
+                )
+                return None
+            # Use MCPConfig dict format accepted by create_proxy()
+            return create_proxy(
+                {
+                    "mcpServers": {
+                        resource.name: {
+                            "command": resource.command,
+                            "args": resource.args,
+                            "env": resource.env,
+                        }
+                    }
+                }
+            )
+
+        logger.warning(
+            "Unsupported transport type '%s' for resource '%s' — skipping",
+            resource.transport_type,
+            resource.name,
+        )
+        return None

--- a/python/helpers/mcp_gateway_health.py
+++ b/python/helpers/mcp_gateway_health.py
@@ -1,0 +1,75 @@
+"""Gateway health checker for connection pool and Docker containers.
+
+Provides periodic health checking for the MCP gateway, combining
+connection pool health checks with Docker container status monitoring.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from python.helpers.mcp_connection_pool import McpConnectionPool
+from python.helpers.mcp_container_manager import McpContainerManager
+from python.helpers.mcp_resource_store import InMemoryMcpResourceStore
+
+logger = logging.getLogger(__name__)
+
+
+class McpGatewayHealthChecker:
+    """Orchestrates health checks across pool and Docker containers."""
+
+    def __init__(
+        self,
+        pool: McpConnectionPool,
+        store: InMemoryMcpResourceStore,
+    ) -> None:
+        self._pool = pool
+        self._store = store
+
+    async def run_health_check(self) -> dict[str, Any]:
+        """Run a full health check on the connection pool."""
+        try:
+            await self._pool.health_check()
+            return {"ok": True, "pool_active": self._pool.active_count}
+        except Exception as exc:
+            logger.warning("Gateway health check failed: %s", exc)
+            return {"ok": False, "error": str(exc)}
+
+    async def check_docker_servers(self) -> list[dict[str, Any]]:
+        """Check Docker container status for Docker-backed servers."""
+        results: list[dict[str, Any]] = []
+        resources = self._store.list_all()
+        docker_resources = [r for r in resources if r.docker_image]
+
+        if not docker_resources:
+            return results
+
+        try:
+            manager = McpContainerManager()
+        except Exception as exc:
+            logger.warning("Cannot connect to Docker: %s", exc)
+            return [
+                {"name": r.name, "running": False, "error": "Docker unavailable"}
+                for r in docker_resources
+            ]
+
+        for resource in docker_resources:
+            status = manager.get_status(resource.name)
+            results.append(
+                {
+                    "name": resource.name,
+                    "running": status.get("running", False),
+                    "container_id": status.get("container_id"),
+                    "status": status.get("status", "unknown"),
+                }
+            )
+
+        return results
+
+    async def get_status(self) -> dict[str, Any]:
+        """Get combined gateway health status."""
+        return {
+            "pool_connections": self._pool.active_count,
+            "registered_servers": len(self._store.list_all()),
+        }

--- a/python/helpers/mcp_gateway_lifecycle.py
+++ b/python/helpers/mcp_gateway_lifecycle.py
@@ -1,0 +1,86 @@
+"""Gateway lifecycle hooks for server create/delete events.
+
+Orchestrates side effects when gateway servers are registered or removed:
+- Mount/unmount via compositor
+- Docker container start/stop
+- Connection pool eviction
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from python.helpers.mcp_connection_pool import McpConnectionPool
+from python.helpers.mcp_gateway_compositor import McpGatewayCompositor
+from python.helpers.mcp_resource_store import McpServerResource
+
+logger = logging.getLogger(__name__)
+
+
+async def on_server_created(
+    resource: McpServerResource,
+    *,
+    compositor: McpGatewayCompositor,
+    container_manager: Any | None = None,
+) -> None:
+    """Handle side effects after a gateway server is created/registered.
+
+    1. Start Docker container if Docker-backed
+    2. Mount the server via compositor
+    """
+    # Start Docker container if applicable
+    if resource.docker_image and container_manager is not None:
+        try:
+            container_id = container_manager.start_server(resource)
+            logger.info(
+                "Started Docker container for '%s': %s",
+                resource.name,
+                container_id,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to start Docker container for '%s': %s",
+                resource.name,
+                exc,
+            )
+
+    # Mount via compositor
+    try:
+        await compositor.mount_server(resource)
+    except Exception as exc:
+        logger.warning("Failed to mount gateway server '%s': %s", resource.name, exc)
+
+
+async def on_server_deleted(
+    name: str,
+    *,
+    compositor: McpGatewayCompositor,
+    pool: McpConnectionPool,
+    container_manager: Any | None = None,
+) -> None:
+    """Handle side effects after a gateway server is deleted.
+
+    1. Unmount from compositor
+    2. Evict from connection pool
+    3. Stop Docker container if applicable
+    """
+    # Unmount
+    try:
+        await compositor.unmount_server(name)
+    except Exception as exc:
+        logger.warning("Failed to unmount server '%s': %s", name, exc)
+
+    # Evict pool connection
+    try:
+        await pool.evict(name)
+    except Exception as exc:
+        logger.warning("Failed to evict pool connection '%s': %s", name, exc)
+
+    # Stop Docker container if applicable
+    if container_manager is not None:
+        try:
+            container_manager.stop_server(name)
+            logger.info("Stopped Docker container for '%s'", name)
+        except Exception as exc:
+            logger.warning("Failed to stop Docker container for '%s': %s", name, exc)

--- a/python/helpers/mcp_registry_client.py
+++ b/python/helpers/mcp_registry_client.py
@@ -1,0 +1,95 @@
+"""Client for the Official MCP Registry API.
+
+Queries https://registry.modelcontextprotocol.io/v0/servers for
+server discovery, with cursor-based pagination and error resilience.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+REGISTRY_URL = "https://registry.modelcontextprotocol.io/v0/servers"
+
+
+class McpRegistryClient:
+    """Async client for the MCP Registry discovery API."""
+
+    def __init__(self, timeout: float = 10.0) -> None:
+        self.timeout = timeout
+
+    async def search(
+        self,
+        query: str = "",
+        limit: int = 20,
+        cursor: str | None = None,
+    ) -> list[dict]:
+        """Search the MCP Registry for servers.
+
+        Returns a list of parsed server dicts. On any error, returns
+        an empty list rather than raising.
+        """
+        params: dict = {"limit": limit}
+        if query:
+            params["search"] = query
+        if cursor:
+            params["cursor"] = cursor
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                resp = await client.get(REGISTRY_URL, params=params)
+                resp.raise_for_status()
+                data = resp.json()
+        except (httpx.HTTPError, httpx.TimeoutException, ValueError) as exc:
+            logger.warning("MCP Registry search failed: %s", exc)
+            return []
+
+        return [self._parse_server(entry) for entry in data.get("servers", [])]
+
+    async def search_all(
+        self,
+        query: str = "",
+        max_pages: int = 10,
+    ) -> list[dict]:
+        """Paginate through all matching servers up to max_pages."""
+        results: list[dict] = []
+        cursor: str | None = None
+
+        for _ in range(max_pages):
+            params: dict = {"limit": 100}
+            if query:
+                params["search"] = query
+            if cursor:
+                params["cursor"] = cursor
+
+            try:
+                async with httpx.AsyncClient(timeout=self.timeout) as client:
+                    resp = await client.get(REGISTRY_URL, params=params)
+                    resp.raise_for_status()
+                    data = resp.json()
+            except (httpx.HTTPError, httpx.TimeoutException, ValueError) as exc:
+                logger.warning("MCP Registry pagination failed: %s", exc)
+                break
+
+            servers = data.get("servers", [])
+            results.extend(self._parse_server(entry) for entry in servers)
+
+            next_cursor = data.get("metadata", {}).get("nextCursor")
+            if not next_cursor:
+                break
+            cursor = next_cursor
+
+        return results
+
+    @staticmethod
+    def _parse_server(entry: dict) -> dict:
+        """Extract a flat server dict from the registry response format."""
+        server = entry.get("server", {})
+        return {
+            "name": server.get("name", ""),
+            "description": server.get("description", ""),
+            "packages": server.get("packages", []),
+        }

--- a/python/helpers/mcp_tool_index.py
+++ b/python/helpers/mcp_tool_index.py
@@ -1,0 +1,64 @@
+"""Unified tool index across mounted MCP servers.
+
+Provides a searchable index of all tools exposed by gateway-mounted
+MCP servers, enabling keyword search and tool listing.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class McpToolIndex:
+    """Keyword-searchable index of tools from mounted MCP servers."""
+
+    def __init__(self) -> None:
+        # server_name -> list of tool dicts
+        self._tools: dict[str, list[dict[str, Any]]] = {}
+
+    @property
+    def tool_count(self) -> int:
+        """Return total number of registered tools."""
+        return sum(len(tools) for tools in self._tools.values())
+
+    def register_tools(self, server_name: str, tools: list[dict[str, Any]]) -> None:
+        """Register tools from a mounted server."""
+        self._tools[server_name] = [
+            {
+                "server": server_name,
+                "name": t.get("name", ""),
+                "description": t.get("description", ""),
+            }
+            for t in tools
+        ]
+        logger.debug("Registered %d tools from server '%s'", len(tools), server_name)
+
+    def unregister_server(self, server_name: str) -> None:
+        """Remove all tools for a server."""
+        self._tools.pop(server_name, None)
+
+    def list_all_tools(self) -> list[dict[str, Any]]:
+        """Return all registered tools across all servers."""
+        result = []
+        for tools in self._tools.values():
+            result.extend(tools)
+        return result
+
+    def search_tools(self, query: str) -> list[dict[str, Any]]:
+        """Keyword search across tool names, descriptions, and server names."""
+        if not query:
+            return self.list_all_tools()
+
+        query_lower = query.lower()
+        results = []
+        for tools in self._tools.values():
+            for tool in tools:
+                searchable = (
+                    f"{tool['name']} {tool['description']} {tool['server']}"
+                ).lower()
+                if query_lower in searchable:
+                    results.append(tool)
+        return results

--- a/python/tools/mcp_discover.py
+++ b/python/tools/mcp_discover.py
@@ -1,0 +1,106 @@
+"""Agent tool for discovering and installing MCP servers.
+
+Enables the agent to search the MCP Registry and Docker MCP Catalog
+during its monologue loop, and install servers into the gateway.
+"""
+
+from python.helpers.mcp_registry_client import McpRegistryClient
+from python.helpers.mcp_tool_index import McpToolIndex
+from python.helpers.tool import Response, Tool
+
+# Module-level singletons
+_registry_client = McpRegistryClient()
+_tool_index = McpToolIndex()
+
+
+def get_tool_index() -> McpToolIndex:
+    """Return the module-level tool index singleton."""
+    return _tool_index
+
+
+class McpDiscover(Tool):
+    async def execute(self, **kwargs):
+        action = self.args.get("action", "search")
+
+        if action == "search":
+            return await self._search()
+        elif action == "list":
+            return self._list_tools()
+        elif action == "search_tools":
+            return self._search_tools()
+
+        return Response(
+            message=f"Unknown action: {action}. Use 'search', 'list', or 'search_tools'.",
+            break_loop=False,
+        )
+
+    async def _search(self) -> Response:
+        """Search the MCP Registry for servers."""
+        query = self.args.get("query", "")
+        if not query:
+            return Response(
+                message="Please provide a 'query' argument to search for MCP servers.",
+                break_loop=False,
+            )
+
+        results = await _registry_client.search(query, limit=10)
+        if not results:
+            return Response(
+                message=f"No MCP servers found matching '{query}'.",
+                break_loop=False,
+            )
+
+        lines = [f"Found {len(results)} MCP server(s) matching '{query}':\n"]
+        for r in results:
+            packages = ", ".join(
+                f"{p['registry_name']}:{p['name']}" for p in r.get("packages", [])
+            )
+            lines.append(f"- **{r['name']}**: {r.get('description', 'No description')}")
+            if packages:
+                lines.append(f"  Packages: {packages}")
+
+        return Response(message="\n".join(lines), break_loop=False)
+
+    def _list_tools(self) -> Response:
+        """List all tools available across mounted MCP servers."""
+        tools = _tool_index.list_all_tools()
+        if not tools:
+            return Response(
+                message="No MCP server tools currently registered in the tool index.",
+                break_loop=False,
+            )
+
+        lines = [f"Available MCP tools ({len(tools)} total):\n"]
+        by_server: dict[str, list[str]] = {}
+        for t in tools:
+            by_server.setdefault(t["server"], []).append(
+                f"  - {t['name']}: {t['description']}"
+            )
+
+        for server, tool_lines in sorted(by_server.items()):
+            lines.append(f"**{server}**:")
+            lines.extend(tool_lines)
+
+        return Response(message="\n".join(lines), break_loop=False)
+
+    def _search_tools(self) -> Response:
+        """Search across all registered tools."""
+        query = self.args.get("query", "")
+        if not query:
+            return Response(
+                message="Please provide a 'query' argument to search tools.",
+                break_loop=False,
+            )
+
+        results = _tool_index.search_tools(query)
+        if not results:
+            return Response(
+                message=f"No tools found matching '{query}'.",
+                break_loop=False,
+            )
+
+        lines = [f"Found {len(results)} tool(s) matching '{query}':\n"]
+        for t in results:
+            lines.append(f"- **{t['server']}/{t['name']}**: {t['description']}")
+
+        return Response(message="\n".join(lines), break_loop=False)

--- a/tests/test_docker_mcp_catalog.py
+++ b/tests/test_docker_mcp_catalog.py
@@ -1,0 +1,153 @@
+"""Tests for Docker MCP Catalog client."""
+
+from python.helpers.docker_mcp_catalog import (
+    parse_catalog_entries,
+    catalog_entry_to_resource,
+)
+from python.helpers.mcp_resource_store import McpServerResource
+
+
+# ---------- Sample data ----------
+
+SAMPLE_CATALOG = [
+    {
+        "name": "docker/github-mcp",
+        "description": "GitHub MCP server for repository management",
+        "image": "ghcr.io/docker/github-mcp:latest",
+        "transport": "stdio",
+        "args": ["--token", "${GITHUB_TOKEN}"],
+    },
+    {
+        "name": "docker/filesystem-mcp",
+        "description": "Filesystem access MCP server",
+        "image": "ghcr.io/docker/filesystem-mcp:latest",
+        "transport": "streamable_http",
+        "port": 8080,
+    },
+    {
+        "name": "docker/slack-mcp",
+        "description": "Slack integration MCP server",
+        "image": "ghcr.io/docker/slack-mcp:1.2.0",
+        "transport": "sse",
+        "port": 9090,
+        "env": {"SLACK_TOKEN": "${SLACK_TOKEN}"},
+    },
+]
+
+SAMPLE_YAML = """\
+servers:
+  - name: docker/github-mcp
+    description: GitHub MCP server
+    image: ghcr.io/docker/github-mcp:latest
+    transport: stdio
+  - name: docker/filesystem-mcp
+    description: Filesystem access
+    image: ghcr.io/docker/filesystem-mcp:latest
+    transport: streamable_http
+    port: 8080
+"""
+
+
+# ---------- Tests: parse_catalog_entries ----------
+
+
+def test_parse_returns_list():
+    """parse_catalog_entries returns a list of dicts."""
+    results = parse_catalog_entries(SAMPLE_CATALOG)
+    assert isinstance(results, list)
+    assert len(results) == 3
+
+
+def test_parse_preserves_fields():
+    """parse_catalog_entries preserves name, description, image, transport."""
+    results = parse_catalog_entries(SAMPLE_CATALOG)
+    github = results[0]
+    assert github["name"] == "docker/github-mcp"
+    assert github["description"] == "GitHub MCP server for repository management"
+    assert github["image"] == "ghcr.io/docker/github-mcp:latest"
+    assert github["transport"] == "stdio"
+
+
+def test_parse_empty_list():
+    """parse_catalog_entries returns empty list for empty input."""
+    assert parse_catalog_entries([]) == []
+
+
+def test_parse_skips_invalid_entries():
+    """parse_catalog_entries skips entries missing required 'name' field."""
+    entries = [
+        {"description": "No name"},
+        {"name": "valid", "image": "img:latest"},
+    ]
+    results = parse_catalog_entries(entries)
+    assert len(results) == 1
+    assert results[0]["name"] == "valid"
+
+
+def test_parse_includes_optional_fields():
+    """parse_catalog_entries includes port and env when present."""
+    results = parse_catalog_entries(SAMPLE_CATALOG)
+    slack = results[2]
+    assert slack["port"] == 9090
+    assert slack["env"] == {"SLACK_TOKEN": "${SLACK_TOKEN}"}
+
+
+# ---------- Tests: catalog_entry_to_resource ----------
+
+
+def test_entry_to_resource_stdio():
+    """catalog_entry_to_resource creates stdio resource with Docker image."""
+    entry = SAMPLE_CATALOG[0]
+    resource = catalog_entry_to_resource(entry, user_id="admin")
+    assert isinstance(resource, McpServerResource)
+    assert resource.name == "docker/github-mcp"
+    assert resource.docker_image == "ghcr.io/docker/github-mcp:latest"
+    assert resource.transport_type == "stdio"
+    assert resource.created_by == "admin"
+    assert resource.is_enabled is True
+
+
+def test_entry_to_resource_http():
+    """catalog_entry_to_resource creates HTTP resource with Docker image and port."""
+    entry = SAMPLE_CATALOG[1]
+    resource = catalog_entry_to_resource(entry, user_id="admin")
+    assert resource.transport_type == "streamable_http"
+    assert resource.docker_image == "ghcr.io/docker/filesystem-mcp:latest"
+    assert resource.docker_ports == {"8080/tcp": 8080}
+
+
+def test_entry_to_resource_sse():
+    """catalog_entry_to_resource creates SSE resource with Docker image."""
+    entry = SAMPLE_CATALOG[2]
+    resource = catalog_entry_to_resource(entry, user_id="admin")
+    assert resource.transport_type == "sse"
+    assert resource.docker_image == "ghcr.io/docker/slack-mcp:1.2.0"
+    assert resource.docker_ports == {"9090/tcp": 9090}
+
+
+def test_entry_to_resource_includes_env():
+    """catalog_entry_to_resource includes env vars from catalog entry."""
+    entry = SAMPLE_CATALOG[2]
+    resource = catalog_entry_to_resource(entry, user_id="admin")
+    assert resource.env == {"SLACK_TOKEN": "${SLACK_TOKEN}"}
+
+
+def test_entry_to_resource_default_transport():
+    """catalog_entry_to_resource defaults to streamable_http when transport not specified."""
+    entry = {"name": "test", "image": "test:latest"}
+    resource = catalog_entry_to_resource(entry, user_id="admin")
+    assert resource.transport_type == "streamable_http"
+
+
+# ---------- Tests: YAML parsing ----------
+
+
+def test_parse_yaml_content():
+    """parse_catalog_entries can work with pre-parsed YAML data."""
+    import yaml
+
+    data = yaml.safe_load(SAMPLE_YAML)
+    results = parse_catalog_entries(data.get("servers", []))
+    assert len(results) == 2
+    assert results[0]["name"] == "docker/github-mcp"
+    assert results[1]["name"] == "docker/filesystem-mcp"

--- a/tests/test_mcp_gateway_compositor.py
+++ b/tests/test_mcp_gateway_compositor.py
@@ -1,0 +1,230 @@
+"""Tests for MCP Gateway Compositor.
+
+Tests the McpGatewayCompositor that mounts/unmounts MCP servers on a
+FastMCP instance using create_proxy() and mount().
+"""
+
+import pytest
+
+from fastmcp import FastMCP
+
+from python.helpers.mcp_resource_store import McpServerResource
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def main_server():
+    """Fresh FastMCP server for composition."""
+    return FastMCP("test-gateway")
+
+
+@pytest.fixture
+def compositor(main_server):
+    """Compositor bound to the test server."""
+    from python.helpers.mcp_gateway_compositor import McpGatewayCompositor
+
+    return McpGatewayCompositor(main_server)
+
+
+@pytest.fixture
+def http_resource():
+    """HTTP-based MCP server resource."""
+    return McpServerResource(
+        name="github",
+        transport_type="streamable_http",
+        url="http://mcp-github:8000/mcp",
+        created_by="admin",
+    )
+
+
+@pytest.fixture
+def stdio_resource():
+    """Stdio-based MCP server resource."""
+    return McpServerResource(
+        name="filesystem",
+        transport_type="stdio",
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-filesystem"],
+        created_by="admin",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mounting
+# ---------------------------------------------------------------------------
+
+
+class TestMountServer:
+    """Test mounting servers onto the FastMCP instance."""
+
+    async def test_mount_http_server_adds_provider(
+        self, main_server, compositor, http_resource
+    ):
+        initial_count = len(main_server.providers)
+        await compositor.mount_server(http_resource)
+
+        assert len(main_server.providers) == initial_count + 1
+        assert "github" in compositor.mounted_names
+
+    async def test_mount_stdio_server_adds_provider(
+        self, main_server, compositor, stdio_resource
+    ):
+        initial_count = len(main_server.providers)
+        await compositor.mount_server(stdio_resource)
+
+        assert len(main_server.providers) == initial_count + 1
+        assert "filesystem" in compositor.mounted_names
+
+    async def test_mount_multiple_servers(
+        self, main_server, compositor, http_resource, stdio_resource
+    ):
+        initial_count = len(main_server.providers)
+        await compositor.mount_server(http_resource)
+        await compositor.mount_server(stdio_resource)
+
+        assert len(main_server.providers) == initial_count + 2
+        assert compositor.mounted_names == {"github", "filesystem"}
+
+    async def test_mount_disabled_server_skipped(self, compositor):
+        resource = McpServerResource(
+            name="disabled",
+            transport_type="streamable_http",
+            url="http://disabled:8000/mcp",
+            created_by="admin",
+            is_enabled=False,
+        )
+        await compositor.mount_server(resource)
+        assert "disabled" not in compositor.mounted_names
+
+    async def test_namespace_collision_raises(self, compositor, http_resource):
+        await compositor.mount_server(http_resource)
+
+        duplicate = McpServerResource(
+            name="github",
+            transport_type="streamable_http",
+            url="http://other-github:8000/mcp",
+            created_by="admin",
+        )
+        with pytest.raises(ValueError, match="already mounted"):
+            await compositor.mount_server(duplicate)
+
+
+# ---------------------------------------------------------------------------
+# Unmounting
+# ---------------------------------------------------------------------------
+
+
+class TestUnmountServer:
+    """Test removing mounted servers."""
+
+    async def test_unmount_removes_provider(
+        self, main_server, compositor, http_resource
+    ):
+        initial_count = len(main_server.providers)
+        await compositor.mount_server(http_resource)
+        assert len(main_server.providers) == initial_count + 1
+
+        await compositor.unmount_server("github")
+        assert len(main_server.providers) == initial_count
+        assert "github" not in compositor.mounted_names
+
+    async def test_unmount_nonexistent_is_noop(self, compositor):
+        # Should not raise
+        await compositor.unmount_server("nonexistent")
+
+    async def test_unmount_preserves_other_mounts(
+        self, main_server, compositor, http_resource, stdio_resource
+    ):
+        initial_count = len(main_server.providers)
+        await compositor.mount_server(http_resource)
+        await compositor.mount_server(stdio_resource)
+
+        await compositor.unmount_server("github")
+        assert len(main_server.providers) == initial_count + 1
+        assert "filesystem" in compositor.mounted_names
+        assert "github" not in compositor.mounted_names
+
+    async def test_remount_after_unmount(self, main_server, compositor, http_resource):
+        initial_count = len(main_server.providers)
+        await compositor.mount_server(http_resource)
+        await compositor.unmount_server("github")
+
+        # Should be able to re-mount without collision
+        await compositor.mount_server(http_resource)
+        assert len(main_server.providers) == initial_count + 1
+        assert "github" in compositor.mounted_names
+
+
+# ---------------------------------------------------------------------------
+# Disable / Enable
+# ---------------------------------------------------------------------------
+
+
+class TestDisableEnable:
+    """Test temporary visibility control."""
+
+    async def test_disable_hides_tools(self, main_server, compositor, http_resource):
+        await compositor.mount_server(http_resource)
+        await compositor.disable_server("github")
+
+        # Server still tracked as mounted
+        assert "github" in compositor.mounted_names
+        # Provider still in list (just disabled)
+        assert compositor.is_disabled("github")
+
+    async def test_enable_restores_tools(self, main_server, compositor, http_resource):
+        await compositor.mount_server(http_resource)
+        await compositor.disable_server("github")
+        await compositor.enable_server("github")
+
+        assert not compositor.is_disabled("github")
+
+    async def test_disable_nonexistent_is_noop(self, compositor):
+        # Should not raise
+        await compositor.disable_server("nonexistent")
+
+    async def test_enable_nonexistent_is_noop(self, compositor):
+        # Should not raise
+        await compositor.enable_server("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    """Test that errors in mount don't crash the compositor."""
+
+    async def test_unsupported_transport_type_skipped(self, compositor):
+        resource = McpServerResource(
+            name="unknown",
+            transport_type="unsupported_transport",
+            created_by="admin",
+        )
+        await compositor.mount_server(resource)
+        assert "unknown" not in compositor.mounted_names
+
+    async def test_http_resource_without_url_skipped(self, compositor):
+        resource = McpServerResource(
+            name="no-url",
+            transport_type="streamable_http",
+            url=None,
+            created_by="admin",
+        )
+        await compositor.mount_server(resource)
+        assert "no-url" not in compositor.mounted_names
+
+    async def test_stdio_resource_without_command_skipped(self, compositor):
+        resource = McpServerResource(
+            name="no-cmd",
+            transport_type="stdio",
+            command=None,
+            created_by="admin",
+        )
+        await compositor.mount_server(resource)
+        assert "no-cmd" not in compositor.mounted_names

--- a/tests/test_mcp_gateway_discover_api.py
+++ b/tests/test_mcp_gateway_discover_api.py
@@ -1,0 +1,192 @@
+"""Tests for MCP Gateway discovery API endpoint."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from python.api.mcp_gateway_discover import handle_search, handle_install
+from python.helpers.mcp_resource_store import InMemoryMcpResourceStore
+
+
+SAMPLE_RESULT = {
+    "name": "github",
+    "description": "GitHub MCP server",
+    "packages": [
+        {
+            "registry_name": "npm",
+            "name": "@modelcontextprotocol/server-github",
+            "version": "1.0.0",
+        }
+    ],
+}
+
+
+# ---------- Tests: search ----------
+
+
+@pytest.mark.asyncio
+async def test_search_proxies_to_registry_client():
+    """handle_search passes query to registry client and returns results."""
+    with patch("python.api.mcp_gateway_discover._get_registry_client") as mock_get:
+        mock_client = AsyncMock()
+        mock_client.search.return_value = [SAMPLE_RESULT]
+        mock_get.return_value = mock_client
+
+        result = await handle_search(query="github", limit=10)
+
+    assert result["ok"] is True
+    assert len(result["data"]) == 1
+    assert result["data"][0]["name"] == "github"
+    mock_client.search.assert_called_once_with("github", limit=10)
+
+
+@pytest.mark.asyncio
+async def test_search_empty_query():
+    """handle_search with empty query returns all results."""
+    with patch("python.api.mcp_gateway_discover._get_registry_client") as mock_get:
+        mock_client = AsyncMock()
+        mock_client.search.return_value = []
+        mock_get.return_value = mock_client
+
+        result = await handle_search(query="", limit=20)
+
+    assert result["ok"] is True
+    assert result["data"] == []
+
+
+@pytest.mark.asyncio
+async def test_search_returns_error_on_exception():
+    """handle_search returns error dict on unexpected exceptions."""
+    with patch("python.api.mcp_gateway_discover._get_registry_client") as mock_get:
+        mock_client = AsyncMock()
+        mock_client.search.side_effect = RuntimeError("boom")
+        mock_get.return_value = mock_client
+
+        result = await handle_search(query="test")
+
+    assert result["ok"] is False
+    assert "error" in result
+
+
+# ---------- Tests: install ----------
+
+
+@pytest.mark.asyncio
+async def test_install_creates_resource():
+    """handle_install creates a McpServerResource from registry data."""
+    store = InMemoryMcpResourceStore()
+    result = await handle_install(
+        store=store,
+        user_id="user1",
+        server_data={
+            "name": "github",
+            "description": "GitHub MCP server",
+            "packages": [
+                {
+                    "registry_name": "npm",
+                    "name": "@modelcontextprotocol/server-github",
+                    "version": "1.0.0",
+                }
+            ],
+        },
+    )
+
+    assert result["ok"] is True
+    assert result["data"]["name"] == "github"
+    assert store.get("github") is not None
+    assert store.get("github").transport_type == "stdio"
+    assert store.get("github").command == "npx"
+
+
+@pytest.mark.asyncio
+async def test_install_missing_name():
+    """handle_install returns error when name is missing."""
+    store = InMemoryMcpResourceStore()
+    result = await handle_install(
+        store=store,
+        user_id="user1",
+        server_data={"description": "No name"},
+    )
+
+    assert result["ok"] is False
+    assert "name" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_install_npm_package_sets_stdio():
+    """handle_install infers stdio transport for npm packages."""
+    store = InMemoryMcpResourceStore()
+    result = await handle_install(
+        store=store,
+        user_id="user1",
+        server_data={
+            "name": "test-server",
+            "packages": [
+                {"registry_name": "npm", "name": "@test/mcp-server", "version": "2.0.0"}
+            ],
+        },
+    )
+
+    assert result["ok"] is True
+    resource = store.get("test-server")
+    assert resource.transport_type == "stdio"
+    assert resource.command == "npx"
+    assert "-y" in resource.args
+    assert "@test/mcp-server@2.0.0" in resource.args
+
+
+@pytest.mark.asyncio
+async def test_install_pip_package_sets_stdio():
+    """handle_install infers stdio transport for pip/PyPI packages."""
+    store = InMemoryMcpResourceStore()
+    result = await handle_install(
+        store=store,
+        user_id="user1",
+        server_data={
+            "name": "py-server",
+            "packages": [
+                {"registry_name": "pip", "name": "mcp-server-py", "version": "1.0.0"}
+            ],
+        },
+    )
+
+    assert result["ok"] is True
+    resource = store.get("py-server")
+    assert resource.transport_type == "stdio"
+    assert resource.command == "uvx"
+    assert "mcp-server-py" in resource.args
+
+
+@pytest.mark.asyncio
+async def test_install_docker_package_sets_http():
+    """handle_install infers HTTP transport for Docker packages."""
+    store = InMemoryMcpResourceStore()
+    result = await handle_install(
+        store=store,
+        user_id="user1",
+        server_data={
+            "name": "docker-server",
+            "packages": [
+                {"registry_name": "docker", "name": "mcp/server", "version": "latest"}
+            ],
+        },
+    )
+
+    assert result["ok"] is True
+    resource = store.get("docker-server")
+    assert resource.docker_image == "mcp/server:latest"
+
+
+@pytest.mark.asyncio
+async def test_install_no_packages_defaults_to_http():
+    """handle_install defaults to streamable_http when no packages specified."""
+    store = InMemoryMcpResourceStore()
+    result = await handle_install(
+        store=store,
+        user_id="user1",
+        server_data={"name": "bare-server", "packages": []},
+    )
+
+    assert result["ok"] is True
+    resource = store.get("bare-server")
+    assert resource.transport_type == "streamable_http"

--- a/tests/test_mcp_gateway_health.py
+++ b/tests/test_mcp_gateway_health.py
@@ -1,0 +1,113 @@
+"""Tests for MCP Gateway health check and lifecycle."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from python.helpers.mcp_gateway_health import McpGatewayHealthChecker
+
+
+@pytest.fixture
+def mock_pool():
+    pool = AsyncMock()
+    pool.health_check = AsyncMock()
+    pool.active_count = 0
+    pool._connections = {}
+    return pool
+
+
+@pytest.fixture
+def mock_store():
+    store = MagicMock()
+    store.list_all.return_value = []
+    return store
+
+
+@pytest.fixture
+def checker(mock_pool, mock_store):
+    return McpGatewayHealthChecker(pool=mock_pool, store=mock_store)
+
+
+# ---------- Tests: run_health_check ----------
+
+
+@pytest.mark.asyncio
+async def test_health_check_calls_pool(checker, mock_pool):
+    """run_health_check invokes pool.health_check()."""
+    await checker.run_health_check()
+    mock_pool.health_check.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_health_check_returns_result(checker):
+    """run_health_check returns a result dict."""
+    result = await checker.run_health_check()
+    assert "ok" in result
+    assert result["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_health_check_handles_pool_error(checker, mock_pool):
+    """run_health_check handles pool errors gracefully."""
+    mock_pool.health_check.side_effect = RuntimeError("pool broken")
+    result = await checker.run_health_check()
+    assert result["ok"] is False
+    assert "error" in result
+
+
+# ---------- Tests: check_docker_servers ----------
+
+
+@pytest.mark.asyncio
+async def test_check_docker_skips_non_docker(checker, mock_store):
+    """check_docker_servers skips servers without docker_image."""
+    from python.helpers.mcp_resource_store import McpServerResource
+
+    mock_store.list_all.return_value = [
+        McpServerResource(name="local", transport_type="stdio", created_by="admin")
+    ]
+    result = await checker.check_docker_servers()
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_check_docker_reports_status(checker, mock_store):
+    """check_docker_servers reports status for Docker-backed servers."""
+    from python.helpers.mcp_resource_store import McpServerResource
+
+    mock_store.list_all.return_value = [
+        McpServerResource(
+            name="github",
+            transport_type="stdio",
+            created_by="admin",
+            docker_image="ghcr.io/mcp/github:latest",
+        )
+    ]
+    with patch("python.helpers.mcp_gateway_health.McpContainerManager") as mock_mgr_cls:
+        mock_mgr = MagicMock()
+        mock_mgr.get_status.return_value = {
+            "running": True,
+            "container_id": "abc123",
+            "status": "running",
+        }
+        mock_mgr_cls.return_value = mock_mgr
+
+        result = await checker.check_docker_servers()
+
+    assert len(result) == 1
+    assert result[0]["name"] == "github"
+    assert result[0]["running"] is True
+
+
+# ---------- Tests: get_status ----------
+
+
+@pytest.mark.asyncio
+async def test_get_status_includes_pool_and_store_info(checker, mock_pool, mock_store):
+    """get_status returns combined pool and store information."""
+    mock_pool.active_count = 3
+    mock_store.list_all.return_value = [MagicMock(), MagicMock()]
+
+    result = await checker.get_status()
+    assert result["pool_connections"] == 3
+    assert result["registered_servers"] == 2

--- a/tests/test_mcp_gateway_lifecycle.py
+++ b/tests/test_mcp_gateway_lifecycle.py
@@ -1,0 +1,134 @@
+"""Tests for MCP Gateway lifecycle hooks (create/delete side effects)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from python.helpers.mcp_gateway_lifecycle import (
+    on_server_created,
+    on_server_deleted,
+)
+from python.helpers.mcp_resource_store import McpServerResource
+
+
+@pytest.fixture
+def http_resource():
+    return McpServerResource(
+        name="github",
+        transport_type="streamable_http",
+        url="http://localhost:8080/mcp",
+        created_by="admin",
+    )
+
+
+@pytest.fixture
+def docker_resource():
+    return McpServerResource(
+        name="docker-server",
+        transport_type="streamable_http",
+        created_by="admin",
+        docker_image="ghcr.io/mcp/server:latest",
+        docker_ports={"8080/tcp": 8080},
+    )
+
+
+# ---------- Tests: on_server_created ----------
+
+
+@pytest.mark.asyncio
+async def test_create_mounts_via_compositor(http_resource):
+    """on_server_created mounts the server via compositor."""
+    compositor = AsyncMock()
+    await on_server_created(http_resource, compositor=compositor)
+    compositor.mount_server.assert_called_once_with(http_resource)
+
+
+@pytest.mark.asyncio
+async def test_create_starts_docker_container(docker_resource):
+    """on_server_created starts Docker container for Docker-backed servers."""
+    compositor = AsyncMock()
+    container_mgr = MagicMock()
+    container_mgr.start_server.return_value = "container-123"
+
+    await on_server_created(
+        docker_resource, compositor=compositor, container_manager=container_mgr
+    )
+
+    container_mgr.start_server.assert_called_once_with(docker_resource)
+    compositor.mount_server.assert_called_once_with(docker_resource)
+
+
+@pytest.mark.asyncio
+async def test_create_skips_docker_if_no_image(http_resource):
+    """on_server_created skips Docker start for non-Docker servers."""
+    compositor = AsyncMock()
+    container_mgr = MagicMock()
+
+    await on_server_created(
+        http_resource, compositor=compositor, container_manager=container_mgr
+    )
+
+    container_mgr.start_server.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_handles_mount_error(http_resource):
+    """on_server_created handles compositor mount errors gracefully."""
+    compositor = AsyncMock()
+    compositor.mount_server.side_effect = RuntimeError("mount failed")
+
+    # Should not raise
+    await on_server_created(http_resource, compositor=compositor)
+
+
+# ---------- Tests: on_server_deleted ----------
+
+
+@pytest.mark.asyncio
+async def test_delete_unmounts_via_compositor():
+    """on_server_deleted unmounts the server."""
+    compositor = AsyncMock()
+    pool = AsyncMock()
+
+    await on_server_deleted("github", compositor=compositor, pool=pool)
+
+    compositor.unmount_server.assert_called_once_with("github")
+
+
+@pytest.mark.asyncio
+async def test_delete_evicts_pool_connection():
+    """on_server_deleted evicts the pool connection."""
+    compositor = AsyncMock()
+    pool = AsyncMock()
+
+    await on_server_deleted("github", compositor=compositor, pool=pool)
+
+    pool.evict.assert_called_once_with("github")
+
+
+@pytest.mark.asyncio
+async def test_delete_stops_docker_container():
+    """on_server_deleted stops Docker container if manager provided."""
+    compositor = AsyncMock()
+    pool = AsyncMock()
+    container_mgr = MagicMock()
+
+    await on_server_deleted(
+        "github",
+        compositor=compositor,
+        pool=pool,
+        container_manager=container_mgr,
+    )
+
+    container_mgr.stop_server.assert_called_once_with("github")
+
+
+@pytest.mark.asyncio
+async def test_delete_handles_errors_gracefully():
+    """on_server_deleted handles errors without raising."""
+    compositor = AsyncMock()
+    compositor.unmount_server.side_effect = RuntimeError("unmount failed")
+    pool = AsyncMock()
+
+    # Should not raise
+    await on_server_deleted("github", compositor=compositor, pool=pool)

--- a/tests/test_mcp_gateway_pool_api.py
+++ b/tests/test_mcp_gateway_pool_api.py
@@ -1,0 +1,138 @@
+"""Tests for MCP Gateway Connection Pool API handler.
+
+Tests the McpGatewayPool API handler that exposes pool diagnostics:
+status, health_check, and evict operations.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from python.helpers.mcp_connection_pool import McpConnectionPool
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pool():
+    """Fresh connection pool for each test."""
+    return McpConnectionPool(max_connections=10)
+
+
+@pytest.fixture
+async def populated_pool(pool):
+    """Pool with two connections."""
+    mock_conn1 = MagicMock()
+    mock_conn2 = MagicMock()
+
+    await pool.acquire("server-a", factory=AsyncMock(return_value=mock_conn1))
+    await pool.release("server-a")
+    await pool.acquire("server-b", factory=AsyncMock(return_value=mock_conn2))
+    await pool.release("server-b")
+    return pool
+
+
+# ---------------------------------------------------------------------------
+# Handler structure
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerStructure:
+    def test_handler_is_api_handler_subclass(self):
+        from python.api.mcp_gateway_pool import McpGatewayPool
+        from python.helpers.api import ApiHandler
+
+        assert issubclass(McpGatewayPool, ApiHandler)
+
+
+# ---------------------------------------------------------------------------
+# Status action
+# ---------------------------------------------------------------------------
+
+
+class TestStatusAction:
+    def test_status_empty_pool(self, pool):
+        from python.api.mcp_gateway_pool import handle_status
+
+        result = handle_status(pool)
+        assert result["ok"] is True
+        assert result["data"]["active_count"] == 0
+        assert result["data"]["connections"] == []
+
+    async def test_status_populated_pool(self, populated_pool):
+        from python.api.mcp_gateway_pool import handle_status
+
+        result = handle_status(populated_pool)
+        assert result["ok"] is True
+        assert result["data"]["active_count"] == 2
+        assert len(result["data"]["connections"]) == 2
+
+        names = {c["server_name"] for c in result["data"]["connections"]}
+        assert names == {"server-a", "server-b"}
+
+    async def test_status_shows_in_use_flag(self, pool):
+        from python.api.mcp_gateway_pool import handle_status
+
+        mock_conn = MagicMock()
+        await pool.acquire("active-server", factory=AsyncMock(return_value=mock_conn))
+        # Don't release — still in use
+
+        result = handle_status(pool)
+        conn_info = result["data"]["connections"][0]
+        assert conn_info["in_use"] is True
+
+
+# ---------------------------------------------------------------------------
+# Health check action
+# ---------------------------------------------------------------------------
+
+
+class TestHealthCheckAction:
+    async def test_health_check_evicts_unhealthy(self, pool):
+        from python.api.mcp_gateway_pool import handle_health_check
+
+        # Create a connection that reports unhealthy
+        unhealthy_conn = MagicMock()
+        unhealthy_conn.is_healthy = AsyncMock(return_value=False)
+        await pool.acquire("bad-server", factory=AsyncMock(return_value=unhealthy_conn))
+        await pool.release("bad-server")
+
+        result = await handle_health_check(pool)
+        assert result["ok"] is True
+        assert pool.active_count == 0
+
+    async def test_health_check_keeps_healthy(self, pool):
+        from python.api.mcp_gateway_pool import handle_health_check
+
+        healthy_conn = MagicMock()
+        healthy_conn.is_healthy = AsyncMock(return_value=True)
+        await pool.acquire("good-server", factory=AsyncMock(return_value=healthy_conn))
+        await pool.release("good-server")
+
+        result = await handle_health_check(pool)
+        assert result["ok"] is True
+        assert pool.active_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Evict action
+# ---------------------------------------------------------------------------
+
+
+class TestEvictAction:
+    async def test_evict_existing_connection(self, populated_pool):
+        from python.api.mcp_gateway_pool import handle_evict
+
+        result = await handle_evict(populated_pool, name="server-a")
+        assert result["ok"] is True
+        assert populated_pool.active_count == 1
+
+    async def test_evict_nonexistent_returns_ok(self, pool):
+        from python.api.mcp_gateway_pool import handle_evict
+
+        # Evicting a non-existent connection is a no-op (idempotent)
+        result = await handle_evict(pool, name="nonexistent")
+        assert result["ok"] is True

--- a/tests/test_mcp_gateway_servers_api.py
+++ b/tests/test_mcp_gateway_servers_api.py
@@ -1,0 +1,394 @@
+"""Tests for MCP Gateway Servers CRUD API handler.
+
+Tests the McpGatewayServers API handler that manages McpServerResource
+objects through the InMemoryMcpResourceStore.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store():
+    """Fresh in-memory resource store for each test."""
+    from python.helpers.mcp_resource_store import InMemoryMcpResourceStore
+
+    return InMemoryMcpResourceStore()
+
+
+@pytest.fixture
+def sample_resource():
+    """A sample McpServerResource for testing."""
+    from python.helpers.mcp_resource_store import McpServerResource
+
+    return McpServerResource(
+        name="github",
+        transport_type="streamable_http",
+        url="http://mcp-github:8000/mcp",
+        created_by="user1",
+    )
+
+
+@pytest.fixture
+def sample_stdio_resource():
+    """A sample stdio McpServerResource for testing."""
+    from python.helpers.mcp_resource_store import McpServerResource
+
+    return McpServerResource(
+        name="filesystem",
+        transport_type="stdio",
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-filesystem"],
+        created_by="user1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Handler import and class structure
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerStructure:
+    """Verify the handler class exists and follows ApiHandler conventions."""
+
+    def test_handler_is_api_handler_subclass(self):
+        from python.api.mcp_gateway_servers import McpGatewayServers
+        from python.helpers.api import ApiHandler
+
+        assert issubclass(McpGatewayServers, ApiHandler)
+
+    def test_handler_declares_write_permission(self):
+        from python.api.mcp_gateway_servers import McpGatewayServers
+
+        # Handler returns None (handles RBAC dynamically like mcp_services.py)
+        # or returns a specific permission tuple
+        perm = McpGatewayServers.get_required_permission()
+        # Dynamic RBAC: None means handled in process()
+        assert perm is None
+
+
+# ---------------------------------------------------------------------------
+# Resource serialization
+# ---------------------------------------------------------------------------
+
+
+class TestResourceSerialization:
+    """Test resource_to_dict helper."""
+
+    def test_serializes_all_fields(self, sample_resource):
+        from python.api.mcp_gateway_servers import resource_to_dict
+
+        d = resource_to_dict(sample_resource)
+        assert d["name"] == "github"
+        assert d["transport_type"] == "streamable_http"
+        assert d["url"] == "http://mcp-github:8000/mcp"
+        assert d["created_by"] == "user1"
+        assert d["is_enabled"] is True
+        assert "created_at" in d
+        assert "updated_at" in d
+
+    def test_serializes_stdio_fields(self, sample_stdio_resource):
+        from python.api.mcp_gateway_servers import resource_to_dict
+
+        d = resource_to_dict(sample_stdio_resource)
+        assert d["name"] == "filesystem"
+        assert d["transport_type"] == "stdio"
+        assert d["command"] == "npx"
+        assert d["args"] == ["-y", "@modelcontextprotocol/server-filesystem"]
+
+    def test_serializes_docker_fields(self):
+        from python.helpers.mcp_resource_store import McpServerResource
+        from python.api.mcp_gateway_servers import resource_to_dict
+
+        r = McpServerResource(
+            name="docker-server",
+            transport_type="streamable_http",
+            url="http://localhost:9000/mcp",
+            docker_image="ghcr.io/example/mcp-server:latest",
+            docker_ports={"9000/tcp": 9000},
+            created_by="admin",
+        )
+        d = resource_to_dict(r)
+        assert d["docker_image"] == "ghcr.io/example/mcp-server:latest"
+        assert d["docker_ports"] == {"9000/tcp": 9000}
+
+
+# ---------------------------------------------------------------------------
+# CRUD operations via handler logic
+# ---------------------------------------------------------------------------
+
+
+class TestListAction:
+    """Test action='list' returns resources from the store."""
+
+    def test_list_empty_store(self, store):
+        from python.api.mcp_gateway_servers import handle_list
+
+        result = handle_list(store, user_id="user1", roles=[])
+        assert result["ok"] is True
+        assert result["data"] == []
+
+    def test_list_returns_accessible_resources(self, store, sample_resource):
+        from python.api.mcp_gateway_servers import handle_list
+
+        store.upsert(sample_resource)
+        result = handle_list(store, user_id="user1", roles=[])
+        assert result["ok"] is True
+        assert len(result["data"]) == 1
+        assert result["data"][0]["name"] == "github"
+
+    def test_list_filters_by_access(self, store):
+        from python.helpers.mcp_resource_store import McpServerResource
+        from python.api.mcp_gateway_servers import handle_list
+
+        # Public resource (no required roles)
+        store.upsert(
+            McpServerResource(name="public", transport_type="stdio", created_by="admin")
+        )
+        # Restricted resource (requires 'engineering' role)
+        store.upsert(
+            McpServerResource(
+                name="restricted",
+                transport_type="stdio",
+                created_by="admin",
+                required_roles=["engineering"],
+            )
+        )
+
+        # User without engineering role sees only public
+        result = handle_list(store, user_id="other_user", roles=["sales"])
+        assert len(result["data"]) == 1
+        assert result["data"][0]["name"] == "public"
+
+    def test_list_admin_sees_all(self, store):
+        from python.helpers.mcp_resource_store import McpServerResource
+        from python.api.mcp_gateway_servers import handle_list
+
+        store.upsert(
+            McpServerResource(
+                name="restricted",
+                transport_type="stdio",
+                created_by="someone",
+                required_roles=["engineering"],
+            )
+        )
+
+        result = handle_list(store, user_id="admin", roles=["mcp.admin"])
+        assert len(result["data"]) == 1
+
+
+class TestCreateAction:
+    """Test action='create' adds resources to the store."""
+
+    def test_create_http_server(self, store):
+        from python.api.mcp_gateway_servers import handle_create
+
+        result = handle_create(
+            store,
+            user_id="user1",
+            data={
+                "name": "github",
+                "transport_type": "streamable_http",
+                "url": "http://mcp-github:8000/mcp",
+            },
+        )
+        assert result["ok"] is True
+        assert result["data"]["name"] == "github"
+        assert store.get("github") is not None
+
+    def test_create_stdio_server(self, store):
+        from python.api.mcp_gateway_servers import handle_create
+
+        result = handle_create(
+            store,
+            user_id="user1",
+            data={
+                "name": "filesystem",
+                "transport_type": "stdio",
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem"],
+            },
+        )
+        assert result["ok"] is True
+        assert result["data"]["command"] == "npx"
+
+    def test_create_missing_name_returns_error(self, store):
+        from python.api.mcp_gateway_servers import handle_create
+
+        result = handle_create(
+            store,
+            user_id="user1",
+            data={"transport_type": "stdio"},
+        )
+        assert result.get("ok") is not True
+        assert "error" in result
+
+    def test_create_missing_transport_type_returns_error(self, store):
+        from python.api.mcp_gateway_servers import handle_create
+
+        result = handle_create(
+            store,
+            user_id="user1",
+            data={"name": "test"},
+        )
+        assert result.get("ok") is not True
+        assert "error" in result
+
+    def test_create_sets_created_by(self, store):
+        from python.api.mcp_gateway_servers import handle_create
+
+        handle_create(
+            store,
+            user_id="user42",
+            data={"name": "test", "transport_type": "stdio"},
+        )
+        resource = store.get("test")
+        assert resource is not None
+        assert resource.created_by == "user42"
+
+    def test_create_with_docker_config(self, store):
+        from python.api.mcp_gateway_servers import handle_create
+
+        result = handle_create(
+            store,
+            user_id="user1",
+            data={
+                "name": "docker-server",
+                "transport_type": "streamable_http",
+                "url": "http://localhost:9000/mcp",
+                "docker_image": "ghcr.io/example/mcp-server:latest",
+                "docker_ports": {"9000/tcp": 9000},
+            },
+        )
+        assert result["ok"] is True
+        resource = store.get("docker-server")
+        assert resource.docker_image == "ghcr.io/example/mcp-server:latest"
+
+    def test_create_with_required_roles(self, store):
+        from python.api.mcp_gateway_servers import handle_create
+
+        result = handle_create(
+            store,
+            user_id="admin",
+            data={
+                "name": "restricted",
+                "transport_type": "stdio",
+                "required_roles": ["engineering"],
+            },
+        )
+        assert result["ok"] is True
+        resource = store.get("restricted")
+        assert resource.required_roles == ["engineering"]
+
+
+class TestUpdateAction:
+    """Test action='update' modifies existing resources."""
+
+    def test_update_existing_resource(self, store, sample_resource):
+        from python.api.mcp_gateway_servers import handle_update
+
+        store.upsert(sample_resource)
+        result = handle_update(
+            store,
+            user_id="user1",
+            roles=[],
+            data={"name": "github", "url": "http://new-url:8000/mcp"},
+        )
+        assert result["ok"] is True
+        assert result["data"]["url"] == "http://new-url:8000/mcp"
+
+    def test_update_nonexistent_returns_error(self, store):
+        from python.api.mcp_gateway_servers import handle_update
+
+        result = handle_update(
+            store,
+            user_id="user1",
+            roles=[],
+            data={"name": "nonexistent", "url": "http://new:8000"},
+        )
+        assert result.get("ok") is not True
+        assert "error" in result
+
+    def test_update_requires_write_access(self, store, sample_resource):
+        from python.api.mcp_gateway_servers import handle_update
+
+        store.upsert(sample_resource)  # created_by="user1"
+        result = handle_update(
+            store,
+            user_id="other_user",  # Not the creator
+            roles=[],  # Not admin
+            data={"name": "github", "url": "http://hacked:8000"},
+        )
+        assert result.get("ok") is not True
+        assert "error" in result or "forbidden" in str(result).lower()
+
+
+class TestDeleteAction:
+    """Test action='delete' removes resources."""
+
+    def test_delete_existing(self, store, sample_resource):
+        from python.api.mcp_gateway_servers import handle_delete
+
+        store.upsert(sample_resource)
+        result = handle_delete(
+            store,
+            user_id="user1",
+            roles=[],
+            name="github",
+        )
+        assert result["ok"] is True
+        assert store.get("github") is None
+
+    def test_delete_nonexistent_returns_error(self, store):
+        from python.api.mcp_gateway_servers import handle_delete
+
+        result = handle_delete(store, user_id="user1", roles=[], name="nope")
+        assert result.get("ok") is not True
+        assert "error" in result
+
+    def test_delete_requires_write_access(self, store, sample_resource):
+        from python.api.mcp_gateway_servers import handle_delete
+
+        store.upsert(sample_resource)  # created_by="user1"
+        result = handle_delete(
+            store,
+            user_id="other_user",
+            roles=[],
+            name="github",
+        )
+        assert result.get("ok") is not True
+
+
+class TestStatusAction:
+    """Test action='status' returns server status."""
+
+    def test_status_returns_container_info(self, store, sample_resource):
+        from python.api.mcp_gateway_servers import handle_status
+
+        store.upsert(sample_resource)
+
+        # Mock container manager to avoid Docker dependency
+        mock_cm = MagicMock()
+        mock_cm.get_status.return_value = {
+            "running": True,
+            "container_id": "abc123",
+            "status": "running",
+        }
+
+        result = handle_status(store, name="github", container_manager=mock_cm)
+        assert result["ok"] is True
+        assert result["data"]["name"] == "github"
+        assert "container" in result["data"]
+
+    def test_status_nonexistent_returns_error(self, store):
+        from python.api.mcp_gateway_servers import handle_status
+
+        result = handle_status(store, name="nonexistent")
+        assert result.get("ok") is not True
+        assert "error" in result

--- a/tests/test_mcp_identity_integration.py
+++ b/tests/test_mcp_identity_integration.py
@@ -1,0 +1,86 @@
+"""Tests for MCP identity header injection integration."""
+
+from python.helpers.mcp_identity import (
+    build_identity_headers,
+    prepare_proxy_headers,
+    strip_auth_headers,
+)
+
+
+# ---------- Tests: build_identity_headers ----------
+
+
+def test_build_identity_headers_basic():
+    """build_identity_headers creates X-Mcp-* headers from user dict."""
+    user = {"id": "user-123", "name": "Alice", "roles": ["admin", "dev"]}
+    headers = build_identity_headers(user)
+    assert headers["X-Mcp-UserId"] == "user-123"
+    assert headers["X-Mcp-UserName"] == "Alice"
+    assert headers["X-Mcp-Roles"] == "admin,dev"
+
+
+def test_build_identity_headers_empty_user():
+    """build_identity_headers handles empty user dict."""
+    headers = build_identity_headers({})
+    assert headers["X-Mcp-UserId"] == ""
+    assert headers["X-Mcp-UserName"] == ""
+    assert headers["X-Mcp-Roles"] == ""
+
+
+def test_build_identity_headers_no_roles():
+    """build_identity_headers handles user without roles."""
+    user = {"id": "user-1", "name": "Bob"}
+    headers = build_identity_headers(user)
+    assert headers["X-Mcp-Roles"] == ""
+
+
+# ---------- Tests: strip_auth_headers ----------
+
+
+def test_strip_removes_auth_headers():
+    """strip_auth_headers removes Authorization, Cookie, X-CSRF-Token."""
+    headers = {
+        "Authorization": "Bearer abc",
+        "Cookie": "session=xyz",
+        "X-CSRF-Token": "token",
+        "Content-Type": "application/json",
+        "Accept": "text/html",
+    }
+    cleaned = strip_auth_headers(headers)
+    assert "Authorization" not in cleaned
+    assert "Cookie" not in cleaned
+    assert "X-CSRF-Token" not in cleaned
+    assert cleaned["Content-Type"] == "application/json"
+    assert cleaned["Accept"] == "text/html"
+
+
+def test_strip_case_insensitive():
+    """strip_auth_headers is case-insensitive."""
+    headers = {"authorization": "Bearer abc", "COOKIE": "session=xyz"}
+    cleaned = strip_auth_headers(headers)
+    assert len(cleaned) == 0
+
+
+def test_strip_preserves_other_headers():
+    """strip_auth_headers preserves non-auth headers."""
+    headers = {"X-Custom": "value", "Host": "example.com"}
+    cleaned = strip_auth_headers(headers)
+    assert cleaned == headers
+
+
+# ---------- Tests: prepare_proxy_headers ----------
+
+
+def test_prepare_proxy_headers_combined():
+    """prepare_proxy_headers strips auth and injects identity."""
+    original = {
+        "Authorization": "Bearer secret",
+        "Content-Type": "application/json",
+    }
+    user = {"id": "u1", "name": "Test", "roles": ["viewer"]}
+    result = prepare_proxy_headers(original, user)
+    assert "Authorization" not in result
+    assert result["Content-Type"] == "application/json"
+    assert result["X-Mcp-UserId"] == "u1"
+    assert result["X-Mcp-UserName"] == "Test"
+    assert result["X-Mcp-Roles"] == "viewer"

--- a/tests/test_mcp_registry_client.py
+++ b/tests/test_mcp_registry_client.py
@@ -1,0 +1,298 @@
+"""Tests for MCP Registry discovery client."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from python.helpers.mcp_registry_client import McpRegistryClient, REGISTRY_URL
+
+
+# ---------- Fixtures ----------
+
+
+@pytest.fixture
+def client():
+    return McpRegistryClient()
+
+
+def _make_response(json_data, status_code=200):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=resp
+        )
+    return resp
+
+
+SAMPLE_SERVER = {
+    "server": {
+        "name": "github",
+        "description": "GitHub MCP server for repository management",
+        "packages": [
+            {
+                "registry_name": "npm",
+                "name": "@modelcontextprotocol/server-github",
+                "version": "1.0.0",
+            }
+        ],
+    },
+    "_meta": {"updated_at": "2025-06-01T00:00:00Z"},
+}
+
+
+# ---------- Tests: search ----------
+
+
+@pytest.mark.asyncio
+async def test_search_returns_servers(client):
+    """search() returns parsed server list from registry API."""
+    response_data = {
+        "servers": [SAMPLE_SERVER],
+        "metadata": {"count": 1, "nextCursor": None},
+    }
+    with patch("python.helpers.mcp_registry_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get.return_value = _make_response(response_data)
+
+        results = await client.search("github")
+
+    assert len(results) == 1
+    assert results[0]["name"] == "github"
+    assert results[0]["description"] == "GitHub MCP server for repository management"
+    assert len(results[0]["packages"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_search_empty_query(client):
+    """search() with empty query returns all servers."""
+    response_data = {
+        "servers": [SAMPLE_SERVER],
+        "metadata": {"count": 1, "nextCursor": None},
+    }
+    with patch("python.helpers.mcp_registry_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get.return_value = _make_response(response_data)
+
+        results = await client.search("")
+
+    mock_client.get.assert_called_once()
+    assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_search_with_limit(client):
+    """search() passes limit parameter to API."""
+    response_data = {"servers": [], "metadata": {"count": 0, "nextCursor": None}}
+    with patch("python.helpers.mcp_registry_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get.return_value = _make_response(response_data)
+
+        await client.search("test", limit=5)
+
+    call_kwargs = mock_client.get.call_args
+    assert call_kwargs[1]["params"]["limit"] == 5
+
+
+@pytest.mark.asyncio
+async def test_search_with_cursor(client):
+    """search() passes cursor for pagination."""
+    response_data = {"servers": [], "metadata": {"count": 0, "nextCursor": None}}
+    with patch("python.helpers.mcp_registry_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get.return_value = _make_response(response_data)
+
+        await client.search("test", cursor="abc123")
+
+    call_kwargs = mock_client.get.call_args
+    assert call_kwargs[1]["params"]["cursor"] == "abc123"
+
+
+@pytest.mark.asyncio
+async def test_search_empty_results(client):
+    """search() returns empty list when no servers match."""
+    response_data = {"servers": [], "metadata": {"count": 0, "nextCursor": None}}
+    with patch("python.helpers.mcp_registry_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get.return_value = _make_response(response_data)
+
+        results = await client.search("nonexistent")
+
+    assert results == []
+
+
+# ---------- Tests: error handling ----------
+
+
+@pytest.mark.asyncio
+async def test_search_network_error_returns_empty(client):
+    """search() returns empty list on network errors, not crash."""
+    with patch("python.helpers.mcp_registry_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get.side_effect = httpx.ConnectError("Connection refused")
+
+        results = await client.search("test")
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_timeout_returns_empty(client):
+    """search() returns empty list on timeout."""
+    with patch("python.helpers.mcp_registry_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get.side_effect = httpx.TimeoutException("Timed out")
+
+        results = await client.search("test")
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_http_error_returns_empty(client):
+    """search() returns empty list on HTTP error status."""
+    with patch("python.helpers.mcp_registry_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get.return_value = _make_response({}, status_code=500)
+
+        results = await client.search("test")
+
+    assert results == []
+
+
+# ---------- Tests: search_all (pagination) ----------
+
+
+@pytest.mark.asyncio
+async def test_search_all_paginates(client):
+    """search_all() follows nextCursor until exhausted."""
+    page1 = {
+        "servers": [SAMPLE_SERVER],
+        "metadata": {"count": 1, "nextCursor": "page2_cursor"},
+    }
+    server2 = {
+        "server": {
+            "name": "filesystem",
+            "description": "Filesystem MCP server",
+            "packages": [],
+        },
+        "_meta": {},
+    }
+    page2 = {
+        "servers": [server2],
+        "metadata": {"count": 1, "nextCursor": None},
+    }
+
+    with patch("python.helpers.mcp_registry_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get.side_effect = [
+            _make_response(page1),
+            _make_response(page2),
+        ]
+
+        results = await client.search_all("test")
+
+    assert len(results) == 2
+    assert results[0]["name"] == "github"
+    assert results[1]["name"] == "filesystem"
+    assert mock_client.get.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_search_all_max_pages_limit(client):
+    """search_all() stops after max_pages to prevent infinite loops."""
+    page_data = {
+        "servers": [SAMPLE_SERVER],
+        "metadata": {"count": 1, "nextCursor": "always_more"},
+    }
+
+    with patch("python.helpers.mcp_registry_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get.return_value = _make_response(page_data)
+
+        results = await client.search_all("test", max_pages=3)
+
+    assert mock_client.get.call_count == 3
+    assert len(results) == 3
+
+
+# ---------- Tests: response parsing ----------
+
+
+@pytest.mark.asyncio
+async def test_parse_extracts_transport_from_packages(client):
+    """Parsed result includes transport info inferred from packages."""
+    server_with_npm = {
+        "server": {
+            "name": "test-server",
+            "description": "Test",
+            "packages": [
+                {
+                    "registry_name": "npm",
+                    "name": "@test/mcp-server",
+                    "version": "1.0.0",
+                }
+            ],
+        },
+        "_meta": {},
+    }
+    response_data = {
+        "servers": [server_with_npm],
+        "metadata": {"count": 1, "nextCursor": None},
+    }
+    with patch("python.helpers.mcp_registry_client.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get.return_value = _make_response(response_data)
+
+        results = await client.search("test")
+
+    assert results[0]["packages"][0]["registry_name"] == "npm"
+
+
+# ---------- Tests: configurable timeout ----------
+
+
+def test_custom_timeout():
+    """Client accepts custom timeout."""
+    c = McpRegistryClient(timeout=30.0)
+    assert c.timeout == 30.0
+
+
+def test_default_timeout():
+    """Default timeout is 10 seconds."""
+    c = McpRegistryClient()
+    assert c.timeout == 10.0
+
+
+# ---------- Tests: URL ----------
+
+
+def test_registry_url_constant():
+    """Registry URL points to official MCP registry."""
+    assert "registry.modelcontextprotocol.io" in REGISTRY_URL
+    assert "/v0/servers" in REGISTRY_URL

--- a/tests/test_mcp_tool_index.py
+++ b/tests/test_mcp_tool_index.py
@@ -1,0 +1,140 @@
+"""Tests for MCP unified tool index."""
+
+from python.helpers.mcp_tool_index import McpToolIndex
+
+
+# ---------- Tests: list_all_tools ----------
+
+
+def test_list_empty():
+    """list_all_tools returns empty list when no tools registered."""
+    index = McpToolIndex()
+    assert index.list_all_tools() == []
+
+
+def test_register_and_list():
+    """register_tools adds tools that appear in list_all_tools."""
+    index = McpToolIndex()
+    index.register_tools(
+        "github",
+        [
+            {"name": "create_issue", "description": "Create a GitHub issue"},
+            {"name": "list_repos", "description": "List repositories"},
+        ],
+    )
+    tools = index.list_all_tools()
+    assert len(tools) == 2
+    assert tools[0]["server"] == "github"
+    assert tools[0]["name"] == "create_issue"
+
+
+def test_register_multiple_servers():
+    """register_tools from multiple servers are all listed."""
+    index = McpToolIndex()
+    index.register_tools("github", [{"name": "create_issue", "description": ""}])
+    index.register_tools("filesystem", [{"name": "read_file", "description": ""}])
+    tools = index.list_all_tools()
+    assert len(tools) == 2
+    servers = {t["server"] for t in tools}
+    assert servers == {"github", "filesystem"}
+
+
+def test_unregister_server():
+    """unregister_server removes all tools for that server."""
+    index = McpToolIndex()
+    index.register_tools("github", [{"name": "create_issue", "description": ""}])
+    index.register_tools("filesystem", [{"name": "read_file", "description": ""}])
+    index.unregister_server("github")
+    tools = index.list_all_tools()
+    assert len(tools) == 1
+    assert tools[0]["server"] == "filesystem"
+
+
+def test_unregister_nonexistent():
+    """unregister_server for unknown server is a no-op."""
+    index = McpToolIndex()
+    index.unregister_server("nonexistent")
+    assert index.list_all_tools() == []
+
+
+# ---------- Tests: search_tools ----------
+
+
+def test_search_by_name():
+    """search_tools matches tool name."""
+    index = McpToolIndex()
+    index.register_tools(
+        "github",
+        [
+            {"name": "create_issue", "description": "Create a GitHub issue"},
+            {"name": "list_repos", "description": "List repositories"},
+        ],
+    )
+    results = index.search_tools("issue")
+    assert len(results) == 1
+    assert results[0]["name"] == "create_issue"
+
+
+def test_search_by_description():
+    """search_tools matches tool description."""
+    index = McpToolIndex()
+    index.register_tools(
+        "fs",
+        [
+            {"name": "read_file", "description": "Read a file from the local disk"},
+            {"name": "write_file", "description": "Write data to a file"},
+        ],
+    )
+    results = index.search_tools("local disk")
+    assert len(results) == 1
+    assert results[0]["name"] == "read_file"
+
+
+def test_search_case_insensitive():
+    """search_tools is case-insensitive."""
+    index = McpToolIndex()
+    index.register_tools("github", [{"name": "CreateIssue", "description": "Creates"}])
+    results = index.search_tools("createissue")
+    assert len(results) == 1
+
+
+def test_search_empty_query():
+    """search_tools with empty query returns all tools."""
+    index = McpToolIndex()
+    index.register_tools("github", [{"name": "a", "description": ""}])
+    index.register_tools("fs", [{"name": "b", "description": ""}])
+    results = index.search_tools("")
+    assert len(results) == 2
+
+
+def test_search_no_results():
+    """search_tools returns empty list when nothing matches."""
+    index = McpToolIndex()
+    index.register_tools("github", [{"name": "create_issue", "description": "Create"}])
+    results = index.search_tools("kubernetes")
+    assert results == []
+
+
+def test_search_by_server_name():
+    """search_tools matches server name."""
+    index = McpToolIndex()
+    index.register_tools("github", [{"name": "create_issue", "description": ""}])
+    index.register_tools("filesystem", [{"name": "read_file", "description": ""}])
+    results = index.search_tools("github")
+    assert len(results) == 1
+    assert results[0]["server"] == "github"
+
+
+# ---------- Tests: tool_count ----------
+
+
+def test_tool_count():
+    """tool_count returns total registered tools."""
+    index = McpToolIndex()
+    assert index.tool_count == 0
+    index.register_tools("a", [{"name": "t1", "description": ""}])
+    assert index.tool_count == 1
+    index.register_tools(
+        "b", [{"name": "t2", "description": ""}, {"name": "t3", "description": ""}]
+    )
+    assert index.tool_count == 3

--- a/webui/components/settings/mcp/gateway/mcp-gateway-store.js
+++ b/webui/components/settings/mcp/gateway/mcp-gateway-store.js
@@ -1,0 +1,215 @@
+import { createStore } from "/js/AlpineStore.js";
+import { callJsonApi } from "/js/api.js";
+
+const model = {
+	// UI state
+	loading: false,
+	error: null,
+	activeView: "servers", // "servers" | "pool"
+	showForm: false,
+	editingServer: null,
+
+	// Data
+	servers: [],
+	poolStatus: null,
+
+	// Form defaults
+	formData: {
+		name: "",
+		transport_type: "streamable_http",
+		url: "",
+		command: "",
+		args: "",
+		docker_image: "",
+		required_roles: "",
+		is_enabled: true,
+	},
+
+	// ---------- Lifecycle ----------
+
+	async init() {
+		await this.loadServers();
+	},
+
+	// ---------- Server CRUD ----------
+
+	async loadServers() {
+		this.loading = true;
+		this.error = null;
+		try {
+			const res = await callJsonApi("/mcp_gateway_servers", {
+				action: "list",
+			});
+			this.servers = res.data || [];
+		} catch (e) {
+			this.error = e.message;
+		}
+		this.loading = false;
+	},
+
+	async createServer() {
+		this.error = null;
+		try {
+			const data = {
+				action: "create",
+				name: this.formData.name,
+				transport_type: this.formData.transport_type,
+				is_enabled: this.formData.is_enabled,
+			};
+			if (this.formData.url) data.url = this.formData.url;
+			if (this.formData.command) data.command = this.formData.command;
+			if (this.formData.args) {
+				data.args = this.formData.args
+					.split(",")
+					.map((s) => s.trim())
+					.filter(Boolean);
+			}
+			if (this.formData.docker_image)
+				data.docker_image = this.formData.docker_image;
+			if (this.formData.required_roles) {
+				data.required_roles = this.formData.required_roles
+					.split(",")
+					.map((s) => s.trim())
+					.filter(Boolean);
+			}
+
+			const res = await callJsonApi("/mcp_gateway_servers", data);
+			if (res.ok) {
+				this.showForm = false;
+				this.resetForm();
+				await this.loadServers();
+			} else {
+				this.error = res.error || "Failed to create server";
+			}
+		} catch (e) {
+			this.error = e.message;
+		}
+	},
+
+	async deleteServer(name) {
+		this.error = null;
+		try {
+			const res = await callJsonApi("/mcp_gateway_servers", {
+				action: "delete",
+				name,
+			});
+			if (res.ok) {
+				await this.loadServers();
+			} else {
+				this.error = res.error || "Failed to delete server";
+			}
+		} catch (e) {
+			this.error = e.message;
+		}
+	},
+
+	async toggleServer(name, enabled) {
+		this.error = null;
+		try {
+			await callJsonApi("/mcp_gateway_servers", {
+				action: "update",
+				name,
+				is_enabled: enabled,
+			});
+			await this.loadServers();
+		} catch (e) {
+			this.error = e.message;
+		}
+	},
+
+	async getServerStatus(name) {
+		try {
+			const res = await callJsonApi("/mcp_gateway_servers", {
+				action: "status",
+				name,
+			});
+			return res.data || {};
+		} catch (e) {
+			this.error = e.message;
+			return {};
+		}
+	},
+
+	// ---------- Connection Pool ----------
+
+	async loadPoolStatus() {
+		this.loading = true;
+		this.error = null;
+		try {
+			const res = await callJsonApi("/mcp_gateway_pool", {
+				action: "status",
+			});
+			this.poolStatus = res.data || null;
+		} catch (e) {
+			this.error = e.message;
+		}
+		this.loading = false;
+	},
+
+	async runHealthCheck() {
+		this.error = null;
+		try {
+			const res = await callJsonApi("/mcp_gateway_pool", {
+				action: "health_check",
+			});
+			if (res.ok) {
+				await this.loadPoolStatus();
+			}
+			return res.data || {};
+		} catch (e) {
+			this.error = e.message;
+			return {};
+		}
+	},
+
+	async evictConnection(name) {
+		this.error = null;
+		try {
+			await callJsonApi("/mcp_gateway_pool", {
+				action: "evict",
+				name,
+			});
+			await this.loadPoolStatus();
+		} catch (e) {
+			this.error = e.message;
+		}
+	},
+
+	// ---------- UI helpers ----------
+
+	openForm() {
+		this.resetForm();
+		this.showForm = true;
+		this.editingServer = null;
+	},
+
+	resetForm() {
+		this.formData = {
+			name: "",
+			transport_type: "streamable_http",
+			url: "",
+			command: "",
+			args: "",
+			docker_image: "",
+			required_roles: "",
+			is_enabled: true,
+		};
+	},
+
+	setView(view) {
+		this.activeView = view;
+		if (view === "pool") this.loadPoolStatus();
+		else this.loadServers();
+	},
+
+	transportLabel(type) {
+		const labels = {
+			streamable_http: "HTTP",
+			sse: "SSE",
+			stdio: "Stdio",
+		};
+		return labels[type] || type;
+	},
+};
+
+export const store = createStore("mcpGateway", model);

--- a/webui/components/settings/mcp/gateway/mcp-gateway.html
+++ b/webui/components/settings/mcp/gateway/mcp-gateway.html
@@ -17,8 +17,8 @@
     <button class="btn btn-sm" @click="$store.mcpGateway.error = null">Dismiss</button>
   </div>
 
-  <!-- Sub-navigation: Servers | Connection Pool | Discover -->
-  <div style="display: flex; gap: 0.5rem; margin-bottom: 1rem;">
+  <!-- Sub-navigation: Servers | Connection Pool | Discover | Catalog -->
+  <div style="display: flex; gap: 0.5rem; margin-bottom: 1rem; flex-wrap: wrap;">
     <button class="btn btn-sm"
             :class="{'btn-primary': $store.mcpGateway.activeView === 'servers'}"
             @click="$store.mcpGateway.setView('servers')">
@@ -33,6 +33,11 @@
             :class="{'btn-primary': $store.mcpGateway.activeView === 'discover'}"
             @click="$store.mcpGateway.setView('discover')">
       Discover Servers
+    </button>
+    <button class="btn btn-sm"
+            :class="{'btn-primary': $store.mcpGateway.activeView === 'catalog'}"
+            @click="$store.mcpGateway.setView('catalog')">
+      Docker Catalog
     </button>
   </div>
 
@@ -309,6 +314,64 @@
     <div x-show="!$store.mcpGateway.loading && !$store.mcpGateway.discoveryQuery"
          style="text-align: center; padding: 2rem; opacity: 0.6;">
       Search the MCP Registry to discover and install servers.
+    </div>
+  </div>
+
+  <!-- ========== Docker Catalog View ========== -->
+  <div x-show="$store.mcpGateway.activeView === 'catalog'">
+
+    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
+      <h3 style="margin: 0;">Docker MCP Catalog</h3>
+    </div>
+
+    <p style="opacity: 0.7; margin-bottom: 1rem;">
+      Paste YAML from <code>docker mcp catalog show docker-mcp</code> to browse and install servers.
+    </p>
+
+    <!-- YAML Input -->
+    <div class="form-group" style="margin-bottom: 0.75rem;">
+      <textarea class="input" rows="8" style="font-family: monospace; width: 100%;"
+                placeholder="servers:&#10;  - name: docker/github-mcp&#10;    image: ghcr.io/docker/github-mcp:latest&#10;    transport: stdio"
+                x-model="$store.mcpGateway.catalogYaml"></textarea>
+    </div>
+    <div style="margin-bottom: 1rem;">
+      <button class="btn btn-sm btn-primary"
+              @click="$store.mcpGateway.browseCatalog($store.mcpGateway.catalogYaml)">
+        <span class="material-symbols-outlined" style="font-size: 1rem;">upload</span>
+        Parse Catalog
+      </button>
+    </div>
+
+    <!-- Loading -->
+    <div x-show="$store.mcpGateway.loading" style="text-align: center; padding: 2rem;">
+      <span class="material-symbols-outlined spinning">progress_activity</span>
+    </div>
+
+    <!-- Catalog Entries -->
+    <div x-show="!$store.mcpGateway.loading && $store.mcpGateway.catalogEntries.length > 0">
+      <template x-for="entry in $store.mcpGateway.catalogEntries" :key="entry.name">
+        <div style="padding: 0.75rem; margin-bottom: 0.5rem; border: 1px solid var(--border-color, #333); border-radius: 8px; display: flex; justify-content: space-between; align-items: flex-start;">
+          <div style="flex: 1;">
+            <div style="font-weight: 600;" x-text="entry.name"></div>
+            <div style="opacity: 0.7; font-size: 0.9em;" x-text="entry.description || 'No description'"></div>
+            <div style="margin-top: 0.25rem;">
+              <span class="badge" x-text="entry.transport || 'http'"></span>
+              <span x-show="entry.image" class="badge" style="margin-left: 0.25rem;" x-text="entry.image"></span>
+            </div>
+          </div>
+          <button class="btn btn-sm btn-primary" style="white-space: nowrap;"
+                  @click="$store.mcpGateway.installFromCatalog(entry)">
+            <span class="material-symbols-outlined" style="font-size: 1rem;">download</span>
+            Install
+          </button>
+        </div>
+      </template>
+    </div>
+
+    <!-- Empty state -->
+    <div x-show="!$store.mcpGateway.loading && $store.mcpGateway.catalogEntries.length === 0 && $store.mcpGateway.catalogYaml"
+         style="text-align: center; padding: 2rem; opacity: 0.6;">
+      No valid entries found in the pasted YAML.
     </div>
   </div>
 </div>

--- a/webui/components/settings/mcp/gateway/mcp-gateway.html
+++ b/webui/components/settings/mcp/gateway/mcp-gateway.html
@@ -17,7 +17,7 @@
     <button class="btn btn-sm" @click="$store.mcpGateway.error = null">Dismiss</button>
   </div>
 
-  <!-- Sub-navigation: Servers | Connection Pool -->
+  <!-- Sub-navigation: Servers | Connection Pool | Discover -->
   <div style="display: flex; gap: 0.5rem; margin-bottom: 1rem;">
     <button class="btn btn-sm"
             :class="{'btn-primary': $store.mcpGateway.activeView === 'servers'}"
@@ -28,6 +28,11 @@
             :class="{'btn-primary': $store.mcpGateway.activeView === 'pool'}"
             @click="$store.mcpGateway.setView('pool')">
       Connection Pool
+    </button>
+    <button class="btn btn-sm"
+            :class="{'btn-primary': $store.mcpGateway.activeView === 'discover'}"
+            @click="$store.mcpGateway.setView('discover')">
+      Discover Servers
     </button>
   </div>
 
@@ -243,6 +248,67 @@
     <div x-show="!$store.mcpGateway.loading && !$store.mcpGateway.poolStatus"
          style="text-align: center; padding: 2rem; opacity: 0.6;">
       Click "Refresh" to load pool status.
+    </div>
+  </div>
+
+  <!-- ========== Discover Servers View ========== -->
+  <div x-show="$store.mcpGateway.activeView === 'discover'">
+
+    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
+      <h3 style="margin: 0;">Discover MCP Servers</h3>
+    </div>
+
+    <!-- Search Bar -->
+    <div style="display: flex; gap: 0.5rem; margin-bottom: 1rem;">
+      <input type="text" class="input" style="flex: 1;"
+             placeholder="Search MCP Registry (e.g. github, filesystem, slack...)"
+             x-model="$store.mcpGateway.discoveryQuery"
+             @keydown.enter="$store.mcpGateway.searchRegistry($store.mcpGateway.discoveryQuery)">
+      <button class="btn btn-sm btn-primary"
+              @click="$store.mcpGateway.searchRegistry($store.mcpGateway.discoveryQuery)">
+        <span class="material-symbols-outlined" style="font-size: 1rem;">search</span>
+        Search
+      </button>
+    </div>
+
+    <!-- Loading -->
+    <div x-show="$store.mcpGateway.loading" style="text-align: center; padding: 2rem;">
+      <span class="material-symbols-outlined spinning">progress_activity</span>
+    </div>
+
+    <!-- Results -->
+    <div x-show="!$store.mcpGateway.loading && $store.mcpGateway.discoveryResults.length > 0">
+      <template x-for="result in $store.mcpGateway.discoveryResults" :key="result.name">
+        <div style="padding: 0.75rem; margin-bottom: 0.5rem; border: 1px solid var(--border-color, #333); border-radius: 8px; display: flex; justify-content: space-between; align-items: flex-start;">
+          <div style="flex: 1;">
+            <div style="font-weight: 600;" x-text="result.name"></div>
+            <div style="opacity: 0.7; font-size: 0.9em;" x-text="result.description || 'No description'"></div>
+            <div x-show="result.packages && result.packages.length > 0" style="margin-top: 0.25rem;">
+              <template x-for="pkg in result.packages" :key="pkg.name">
+                <span class="badge" style="margin-right: 0.25rem;"
+                      x-text="pkg.registry_name + ': ' + pkg.name"></span>
+              </template>
+            </div>
+          </div>
+          <button class="btn btn-sm btn-primary" style="white-space: nowrap;"
+                  @click="$store.mcpGateway.installFromRegistry(result)">
+            <span class="material-symbols-outlined" style="font-size: 1rem;">download</span>
+            Install
+          </button>
+        </div>
+      </template>
+    </div>
+
+    <!-- Empty results -->
+    <div x-show="!$store.mcpGateway.loading && $store.mcpGateway.discoveryResults.length === 0 && $store.mcpGateway.discoveryQuery"
+         style="text-align: center; padding: 2rem; opacity: 0.6;">
+      No servers found matching your search.
+    </div>
+
+    <!-- Initial state -->
+    <div x-show="!$store.mcpGateway.loading && !$store.mcpGateway.discoveryQuery"
+         style="text-align: center; padding: 2rem; opacity: 0.6;">
+      Search the MCP Registry to discover and install servers.
     </div>
   </div>
 </div>

--- a/webui/components/settings/mcp/gateway/mcp-gateway.html
+++ b/webui/components/settings/mcp/gateway/mcp-gateway.html
@@ -1,0 +1,250 @@
+<html>
+<head>
+  <title>MCP Gateway</title>
+</head>
+
+<body>
+<script type="module">
+  import { store as gatewayStore } from "/components/settings/mcp/gateway/mcp-gateway-store.js";
+</script>
+
+<div x-data x-init="$store.mcpGateway.init()">
+
+  <!-- Error Banner -->
+  <div x-show="$store.mcpGateway.error" class="settings-error" style="margin-bottom: 1rem;">
+    <span class="material-symbols-outlined">error</span>
+    <span x-text="$store.mcpGateway.error"></span>
+    <button class="btn btn-sm" @click="$store.mcpGateway.error = null">Dismiss</button>
+  </div>
+
+  <!-- Sub-navigation: Servers | Connection Pool -->
+  <div style="display: flex; gap: 0.5rem; margin-bottom: 1rem;">
+    <button class="btn btn-sm"
+            :class="{'btn-primary': $store.mcpGateway.activeView === 'servers'}"
+            @click="$store.mcpGateway.setView('servers')">
+      Gateway Servers
+    </button>
+    <button class="btn btn-sm"
+            :class="{'btn-primary': $store.mcpGateway.activeView === 'pool'}"
+            @click="$store.mcpGateway.setView('pool')">
+      Connection Pool
+    </button>
+  </div>
+
+  <!-- ========== Server List View ========== -->
+  <div x-show="$store.mcpGateway.activeView === 'servers'">
+
+    <!-- Header + Add Button -->
+    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
+      <h3 style="margin: 0;">Registered Servers</h3>
+      <button class="btn btn-sm btn-primary" @click="$store.mcpGateway.openForm()">
+        <span class="material-symbols-outlined" style="font-size: 1rem;">add</span>
+        Register Server
+      </button>
+    </div>
+
+    <!-- Loading -->
+    <div x-show="$store.mcpGateway.loading" style="text-align: center; padding: 2rem;">
+      <span class="material-symbols-outlined spinning">progress_activity</span>
+    </div>
+
+    <!-- Empty State -->
+    <div x-show="!$store.mcpGateway.loading && $store.mcpGateway.servers.length === 0"
+         style="text-align: center; padding: 2rem; opacity: 0.6;">
+      No gateway servers registered yet. Click "Register Server" to add one.
+    </div>
+
+    <!-- Server Table -->
+    <div x-show="!$store.mcpGateway.loading && $store.mcpGateway.servers.length > 0">
+      <table class="data-table" style="width: 100%;">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Transport</th>
+            <th>URL / Command</th>
+            <th>Enabled</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <template x-for="server in $store.mcpGateway.servers" :key="server.name">
+            <tr>
+              <td x-text="server.name" style="font-weight: 600;"></td>
+              <td>
+                <span class="badge" x-text="$store.mcpGateway.transportLabel(server.transport_type)"></span>
+              </td>
+              <td style="max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                <span x-text="server.url || server.command || '-'"></span>
+              </td>
+              <td>
+                <input type="checkbox"
+                       :checked="server.is_enabled"
+                       @change="$store.mcpGateway.toggleServer(server.name, $event.target.checked)">
+              </td>
+              <td>
+                <button class="btn btn-sm btn-danger"
+                        x-confirm-click="$store.mcpGateway.deleteServer(server.name)"
+                        title="Delete server">
+                  <span class="material-symbols-outlined" style="font-size: 1rem;">delete</span>
+                </button>
+              </td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Register Server Form -->
+    <div x-show="$store.mcpGateway.showForm"
+         style="margin-top: 1rem; padding: 1rem; border: 1px solid var(--border-color, #333); border-radius: 8px;">
+      <h4 style="margin-top: 0;">Register New Server</h4>
+
+      <div class="form-group" style="margin-bottom: 0.75rem;">
+        <label>Name</label>
+        <input type="text" x-model="$store.mcpGateway.formData.name"
+               placeholder="e.g. github, filesystem" class="input">
+      </div>
+
+      <div class="form-group" style="margin-bottom: 0.75rem;">
+        <label>Transport Type</label>
+        <select x-model="$store.mcpGateway.formData.transport_type" class="input">
+          <option value="streamable_http">Streamable HTTP</option>
+          <option value="sse">SSE</option>
+          <option value="stdio">Stdio</option>
+        </select>
+      </div>
+
+      <div class="form-group" style="margin-bottom: 0.75rem;"
+           x-show="$store.mcpGateway.formData.transport_type !== 'stdio'">
+        <label>URL</label>
+        <input type="text" x-model="$store.mcpGateway.formData.url"
+               placeholder="http://mcp-server:8000/mcp" class="input">
+      </div>
+
+      <div x-show="$store.mcpGateway.formData.transport_type === 'stdio'">
+        <div class="form-group" style="margin-bottom: 0.75rem;">
+          <label>Command</label>
+          <input type="text" x-model="$store.mcpGateway.formData.command"
+                 placeholder="npx" class="input">
+        </div>
+        <div class="form-group" style="margin-bottom: 0.75rem;">
+          <label>Args (comma-separated)</label>
+          <input type="text" x-model="$store.mcpGateway.formData.args"
+                 placeholder="-y, @modelcontextprotocol/server-filesystem" class="input">
+        </div>
+      </div>
+
+      <div class="form-group" style="margin-bottom: 0.75rem;">
+        <label>Docker Image (optional)</label>
+        <input type="text" x-model="$store.mcpGateway.formData.docker_image"
+               placeholder="ghcr.io/example/mcp-server:latest" class="input">
+      </div>
+
+      <div class="form-group" style="margin-bottom: 0.75rem;">
+        <label>Required Roles (comma-separated, optional)</label>
+        <input type="text" x-model="$store.mcpGateway.formData.required_roles"
+               placeholder="engineering, admin" class="input">
+      </div>
+
+      <div class="form-group" style="margin-bottom: 0.75rem;">
+        <label>
+          <input type="checkbox" x-model="$store.mcpGateway.formData.is_enabled">
+          Enabled
+        </label>
+      </div>
+
+      <div style="display: flex; gap: 0.5rem;">
+        <button class="btn btn-sm btn-primary" @click="$store.mcpGateway.createServer()">
+          Register
+        </button>
+        <button class="btn btn-sm" @click="$store.mcpGateway.showForm = false">
+          Cancel
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ========== Connection Pool View ========== -->
+  <div x-show="$store.mcpGateway.activeView === 'pool'">
+
+    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
+      <h3 style="margin: 0;">Connection Pool</h3>
+      <div style="display: flex; gap: 0.5rem;">
+        <button class="btn btn-sm" @click="$store.mcpGateway.loadPoolStatus()">
+          <span class="material-symbols-outlined" style="font-size: 1rem;">refresh</span>
+          Refresh
+        </button>
+        <button class="btn btn-sm btn-primary" @click="$store.mcpGateway.runHealthCheck()">
+          <span class="material-symbols-outlined" style="font-size: 1rem;">health_and_safety</span>
+          Health Check
+        </button>
+      </div>
+    </div>
+
+    <!-- Loading -->
+    <div x-show="$store.mcpGateway.loading" style="text-align: center; padding: 2rem;">
+      <span class="material-symbols-outlined spinning">progress_activity</span>
+    </div>
+
+    <!-- Pool Stats -->
+    <div x-show="!$store.mcpGateway.loading && $store.mcpGateway.poolStatus">
+      <div style="display: flex; gap: 2rem; margin-bottom: 1rem;">
+        <div>
+          <strong>Active:</strong>
+          <span x-text="$store.mcpGateway.poolStatus?.active_count ?? 0"></span>
+        </div>
+        <div>
+          <strong>Max:</strong>
+          <span x-text="$store.mcpGateway.poolStatus?.max_connections ?? 0"></span>
+        </div>
+      </div>
+
+      <!-- Connection Table -->
+      <div x-show="$store.mcpGateway.poolStatus?.connections?.length > 0">
+        <table class="data-table" style="width: 100%;">
+          <thead>
+            <tr>
+              <th>Server</th>
+              <th>In Use</th>
+              <th>Last Used</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <template x-for="conn in $store.mcpGateway.poolStatus.connections" :key="conn.server_name">
+              <tr>
+                <td x-text="conn.server_name" style="font-weight: 600;"></td>
+                <td>
+                  <span :class="conn.in_use ? 'badge badge-active' : 'badge'"
+                        x-text="conn.in_use ? 'Active' : 'Idle'"></span>
+                </td>
+                <td x-text="new Date(conn.last_used_at * 1000).toLocaleTimeString()"></td>
+                <td>
+                  <button class="btn btn-sm"
+                          @click="$store.mcpGateway.evictConnection(conn.server_name)"
+                          title="Evict connection">
+                    <span class="material-symbols-outlined" style="font-size: 1rem;">logout</span>
+                  </button>
+                </td>
+              </tr>
+            </template>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Empty pool -->
+      <div x-show="!$store.mcpGateway.poolStatus?.connections?.length"
+           style="text-align: center; padding: 2rem; opacity: 0.6;">
+        No active connections in the pool.
+      </div>
+    </div>
+
+    <!-- No pool data yet -->
+    <div x-show="!$store.mcpGateway.loading && !$store.mcpGateway.poolStatus"
+         style="text-align: center; padding: 2rem; opacity: 0.6;">
+      Click "Refresh" to load pool status.
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/webui/components/settings/mcp/mcp-settings.html
+++ b/webui/components/settings/mcp/mcp-settings.html
@@ -33,6 +33,12 @@
                   <span>Services</span>
                 </a>
               </li>
+              <li>
+                <a href="#section-mcp-gateway">
+                  <img src="/public/mcp_server.svg" alt="MCP Gateway" />
+                  <span>Gateway</span>
+                </a>
+              </li>
             </ul>
           </nav>
 
@@ -47,6 +53,9 @@
           </div>
           <div id="section-mcp-services" class="section">
             <x-component path="settings/mcp/services/mcp-services.html"></x-component>
+          </div>
+          <div id="section-mcp-gateway" class="section">
+            <x-component path="settings/mcp/gateway/mcp-gateway.html"></x-component>
           </div>
         </div>
       </template>


### PR DESCRIPTION
## Description

Complete MCP Gateway Phase 2 implementation adding multi-server composition, registry discovery, Docker catalog support, agent tooling, lifecycle management, and a WebUI management interface.

**10 commits across 8 phases:**

| Phase | Component | New Tests |
|-------|-----------|-----------|
| 1 | Gateway server CRUD API + connection pool status API | 32 |
| 2 | FastMCP 3.0 multi-server compositor + DynamicMcpProxy wiring | 16 |
| 3 | Gateway management WebUI (servers, discover, catalog tabs) | — |
| 4 | MCP Registry discovery client + search/install API | 23 |
| 5 | Docker MCP Catalog YAML parser + browse/install API | 11 |
| 6 | Agent `mcp_discover` tool + unified tool index | 12 |
| 7 | Health checker, lifecycle hooks, identity header tests | 21 |
| 8 | Documentation (CLAUDE.md + Serena memory) | — |

**New files:** 17 (helpers, APIs, tests, tool, prompt, WebUI)
**New tests:** ~115 across 10 test files
**Total suite:** 749 passed, 2 skipped

## Related Issues

- Continues from MCP Gateway Phase 1 (PR #11)

## Type of Change

- [x] New feature
- [x] Documentation update

## Testing

- [x] Existing tests pass (`mise run test`) — 749 passed
- [x] Lint passes (`mise run lint`) — Ruff + Biome clean
- [x] Full CI passes (`mise run ci`)
- [x] I have tested this change locally

## Additional Context

**Architecture:** MCPConfig (agent-side, settings-driven) and McpResourceStore (gateway-side, RBAC-driven) coexist as independent systems. The gateway compositor reads from the resource store; MCPConfig continues managing agent-side servers.

**Key dependencies:** FastMCP 3.0.0rc2 (composition APIs), httpx (registry client) — no new deps added.

**Future phases:** FAISS semantic tool search, Redis-backed store, gateway federation, K8s deployment, Agent-as-Tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)