### PR TITLE
feat(integrations): Platform integration — Slack, GitHub, Jira webhooks and callbacks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# AGENTS.md
+
+Cross-framework agent instructions for Apollos AI. This file complements CLAUDE.md with a format understood by multiple AI coding agents.
+
+## Project
+
+Apollos AI is a personal organic agentic AI framework (Python backend, Alpine.js frontend). Fork of `agent0ai/agent-zero`.
+
+## Build and Test
+
+```bash
+# All commands use mise task runner
+mise run setup           # First-time setup
+mise run r               # Start UI server
+mise run t               # Run tests (pytest)
+mise run lint            # Lint (Ruff + Biome)
+mise run ci              # Full CI: lint + format check + test
+
+# Single test file
+mise run t -- tests/test_example.py -v
+
+# Add a dependency
+mise run deps:add <package>
+```
+
+Do NOT invoke `uv run`, `pytest`, `ruff`, or `docker compose` directly. Always use `mise run <task>`.
+
+## Code Style
+
+- Python: `snake_case` functions, `PascalCase` classes, `str | None` unions (not `Optional`)
+- Commits: Conventional Commits (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`)
+- Pre-commit hooks enforce Ruff lint/format, Biome CSS, and conventional commit messages
+
+## Architecture
+
+- Entry point: `run_ui.py` (Flask + uvicorn + python-socketio)
+- Agent loop: `agent.py` — prompt -> LLM -> parse JSON -> execute tool -> repeat
+- Auto-discovery: Drop files in `python/tools/`, `python/api/`, or `python/websocket_handlers/` and they activate automatically
+- Extensions: `python/extensions/<hook_name>/` with filename-prefix sorting (`_10_`, `_20_`)
+- Settings: `python/helpers/settings.py` TypedDict with `A0_SET_` env var overrides
+
+## Key Patterns
+
+**New API endpoint:** Extend `ApiHandler` in `python/api/`, implement `async process(input, request) -> dict`.
+
+**New tool:** Extend `Tool` in `python/tools/`, implement `async execute(**kwargs) -> Response`.
+
+**New extension:** Extend `Extension` in `python/extensions/<hook>/`, prefix-sorted filename.
+
+## Testing
+
+- Framework: pytest + pytest-asyncio (async auto-detection)
+- Run: `mise run t` or `mise run t -- tests/test_file.py -v`
+- Async tests: Just use `async def test_...` — no decorator needed
+
+## Dependencies
+
+- Source of truth: `pyproject.toml` (managed by uv)
+- Never edit `requirements.txt` manually (auto-generated)
+- Add deps: `mise run deps:add <package>`
+
+## Security
+
+- Secrets in `usr/.env` (gitignored)
+- Vault encryption: AES-256-GCM via `vault_crypto.py`
+- Auth: OIDC (Entra ID) + local Argon2id fallback
+- Webhook verification: HMAC-SHA256 (GitHub, Slack) and shared secret (Jira)
+
+## Gotchas
+
+- faiss-cpu pinned at 1.11.0 — do not upgrade until 1.15.0
+- openai version override in `[tool.uv]` section of pyproject.toml
+- Docker base image uses dash (not bash) — use POSIX shell syntax

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Do NOT invoke `uv run`, `pytest`, `ruff`, or `docker compose` directly. Always u
 - Auto-discovery: Drop files in `python/tools/`, `python/api/`, or `python/websocket_handlers/` and they activate automatically
 - Extensions: `python/extensions/<hook_name>/` with filename-prefix sorting (`_10_`, `_20_`)
 - Settings: `python/helpers/settings.py` TypedDict with `A0_SET_` env var overrides
+- MCP Gateway: `python/helpers/mcp_gateway_*.py` — multi-server composition, discovery, and lifecycle management; APIs in `python/api/mcp_gateway_*.py`; agent tool `mcp_discover`
 
 ## Key Patterns
 

--- a/alembic/versions/005_external_identities.py
+++ b/alembic/versions/005_external_identities.py
@@ -1,0 +1,53 @@
+"""Add external_identities table for platform user linking.
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-02-14
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "005"
+down_revision = "004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "external_identities",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("platform", sa.String(), nullable=False),
+        sa.Column("external_user_id", sa.String(), nullable=False),
+        sa.Column("external_display_name", sa.String()),
+        sa.Column("external_team_id", sa.String()),
+        sa.Column("access_token_vault_id", sa.String()),
+        sa.Column("refresh_token_vault_id", sa.String()),
+        sa.Column("token_expires_at", sa.DateTime()),
+        sa.Column("created_at", sa.DateTime()),
+        sa.Column("last_used_at", sa.DateTime()),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["access_token_vault_id"], ["api_key_vault.id"]),
+        sa.ForeignKeyConstraint(["refresh_token_vault_id"], ["api_key_vault.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("platform", "external_user_id"),
+    )
+    op.create_index(
+        "ix_external_identities_user_id",
+        "external_identities",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_external_identities_platform_user",
+        "external_identities",
+        ["platform", "external_user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_external_identities_platform_user")
+    op.drop_index("ix_external_identities_user_id")
+    op.drop_table("external_identities")

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,13 @@ Welcome to the Apollos AI documentation hub. Whether you're getting started or d
 
 - **[Environment Variables](reference/environment-variables.md):** Complete catalog of all environment variables, API keys, and settings overrides.
 - **[Dependency Management](setup/dependency-management.md):** Adding/removing packages, upstream merge strategy, and Docker compatibility.
-- **[Performance & Scalability Analysis](analysis/performance-scalability-analysis.md):** Detailed analysis of performance characteristics and scalability patterns.
+
+## Platform Integrations
+
+- **[Integrations Overview](integrations/README.md):** Architecture and setup overview for platform integrations.
+- **[Slack Bot Setup](integrations/slack-bot-setup.md):** Configure a Slack App for webhook events.
+- **[GitHub App Setup](integrations/github-app-setup.md):** Configure a GitHub App for issue and PR webhooks.
+- **[Jira Webhook Setup](integrations/jira-webhook-setup.md):** Configure Jira Cloud webhooks.
 
 ## Developer Documentation
 
@@ -103,7 +109,13 @@ Welcome to the Apollos AI documentation hub. Whether you're getting started or d
 
 - [Reference](#reference)
   - [Environment Variables](reference/environment-variables.md)
-  - [Performance & Scalability Analysis](analysis/performance-scalability-analysis.md)
+  - [Dependency Management](setup/dependency-management.md)
+
+- [Platform Integrations](#platform-integrations)
+  - [Integrations Overview](integrations/README.md)
+  - [Slack Bot Setup](integrations/slack-bot-setup.md)
+  - [GitHub App Setup](integrations/github-app-setup.md)
+  - [Jira Webhook Setup](integrations/jira-webhook-setup.md)
 
 - [Developer Documentation](#developer-documentation)
   - [Architecture Overview](developer/architecture.md)

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -110,7 +110,7 @@ A typical interaction flow within Apollos AI might look like this:
 Tools are functionalities that agents can leverage. These can include anything from web search and code execution to interacting with APIs or controlling external software. Apollos AI provides a mechanism for defining and integrating both built-in and custom tools.
 
 #### Built-in Tools
-Apollos AI comes with 19 active built-in tools designed to help agents perform tasks efficiently:
+Apollos AI comes with 20 active built-in tools designed to help agents perform tasks efficiently:
 
 | Tool | Function |
 | --- | --- |
@@ -123,6 +123,7 @@ Apollos AI comes with 19 active built-in tools designed to help agents perform t
 | input | Allows agents to use the keyboard to interact with an active shell |
 | memory_delete | Permanently deletes specific memories from the vector database |
 | memory_forget | Removes memories matching a query from the vector database |
+| mcp_discover | Discovers MCP servers and searches tools across the gateway |
 | memory_load | Retrieves relevant memories from the vector database |
 | memory_save | Stores information in the vector database for later retrieval |
 | notify_user | Sends notifications to the user via the notification system |

--- a/docs/guides/mcp-setup.md
+++ b/docs/guides/mcp-setup.md
@@ -103,6 +103,34 @@ Simply ask Apollos AI to perform tasks, and it will use the appropriate MCP tool
 
 For detailed configuration options, server types, environment variables, and troubleshooting, see the [Advanced MCP Configuration Guide](../developer/mcp-configuration.md).
 
+## MCP Gateway Management
+
+In addition to connecting to external MCP servers as a client, Apollos AI includes a built-in **MCP Gateway** that composes multiple MCP servers into a unified endpoint with access control and lifecycle management.
+
+### Accessing the Gateway
+
+1. Click **Settings** in the sidebar
+2. Navigate to the **MCP/A2A** tab
+3. Click on the **Gateway** section
+
+The Gateway UI has three tabs:
+
+### Servers Tab
+
+Manage MCP servers registered with the gateway. You can add, edit, delete, and check the status of servers. Each server can have RBAC-based access control (creator, admin, and role-based permissions).
+
+### Discover Tab
+
+Search the [MCP Registry](https://registry.modelcontextprotocol.io) for available MCP servers. Browse results and install servers directly into the gateway with one click.
+
+### Docker Catalog Tab
+
+Browse Docker's MCP server catalog. View available containerized MCP servers and install them into the gateway, which handles Docker container lifecycle (start, stop, health check) automatically.
+
+### Agent Discovery
+
+Agents can autonomously discover and search MCP servers using the built-in `mcp_discover` tool. This tool allows agents to search the MCP Registry and find tools across all mounted gateway servers by keyword.
+
 ## Recommended MCP Servers
 
 Community-tested and reliable MCP servers:

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -1,0 +1,68 @@
+# Platform Integrations
+
+Apollos AI can receive events from external platforms via webhooks, process them through the agent loop, and deliver responses back to the originating platform.
+
+## Supported Platforms
+
+| Platform | Webhook Endpoint | Setup Guide |
+|----------|-----------------|-------------|
+| **Slack** | `POST /webhook_slack` | [Slack Bot Setup](slack-bot-setup.md) |
+| **GitHub** | `POST /webhook_github` | [GitHub App Setup](github-app-setup.md) |
+| **Jira** | `POST /webhook_jira` | [Jira Webhook Setup](jira-webhook-setup.md) |
+
+## Architecture
+
+```
+Platform (Slack/GitHub/Jira)
+    │
+    ▼  webhook POST
+┌──────────────────────┐
+│  Webhook Handler     │  Verify signature → parse event → create IntegrationMessage
+│  python/api/         │
+└──────────┬───────────┘
+           │ register callback
+           ▼
+┌──────────────────────┐
+│  Callback Registry   │  In-memory store: conversation_id → CallbackRegistration
+│  python/helpers/     │
+└──────────┬───────────┘
+           │ agent processes
+           ▼
+┌──────────────────────┐
+│  Callback Extension  │  monologue_end hook delivers response to platform
+│  python/extensions/  │
+└──────────┬───────────┘
+           │ API call
+           ▼
+    Platform (response posted)
+```
+
+### Key Components
+
+| Component | File | Purpose |
+|-----------|------|---------|
+| Integration models | `python/helpers/integration_models.py` | Pydantic models: `SourceType`, `IntegrationMessage`, `WebhookContext`, `CallbackRegistration`, `CallbackStatus` |
+| Webhook verification | `python/helpers/webhook_verify.py` | Platform-specific signature verification (HMAC-SHA256 for Slack/GitHub, shared secret for Jira) |
+| Callback registry | `python/helpers/callback_registry.py` | Thread-safe singleton in-memory store for pending callbacks |
+| Callback extension | `python/extensions/monologue_end/_80_integration_callback.py` | Lifecycle hook that delivers agent responses back to platforms |
+| Callback retry | `python/helpers/callback_retry.py` | Exponential backoff retry for failed deliveries |
+| Callback admin API | `python/api/callback_admin.py` | List/retry failed callbacks |
+| Webhook event log | `python/helpers/webhook_event_log.py` | Bounded in-memory audit log of recent inbound events |
+| Event log API | `python/api/webhook_events_get.py` | Query recent webhook events |
+| Settings API | `python/api/integration_settings_get.py` | Read integration config (secrets masked) |
+
+### Settings UI
+
+Configure all platform credentials via **Settings > Integrations** in the web UI, or use `A0_SET_*` environment variables. See [Environment Variables Reference](../reference/environment-variables.md#platform-integrations).
+
+## Enabling Integrations
+
+1. Set the master toggle: `A0_SET_INTEGRATIONS_ENABLED=true` (or toggle in Settings UI)
+2. Configure at least one platform following its setup guide
+3. Ensure your instance is reachable by the platform's webhook delivery (use a tunnel like ngrok for development)
+
+## Monitoring
+
+- **Webhook event log**: `GET /webhook_events_get?limit=50&source=github` — recent inbound events
+- **Callback admin**: `POST /callback_admin` with `{"action": "list"}` — pending/failed callback status
+- **Application logs**: Webhook events are logged with `PrintStyle(font_color="cyan")`

--- a/docs/integrations/github-app-setup.md
+++ b/docs/integrations/github-app-setup.md
@@ -1,0 +1,106 @@
+# GitHub App Setup Guide
+
+This guide walks through creating and configuring a GitHub App to receive webhooks for the Apollos AI platform integration.
+
+## Prerequisites
+
+- A GitHub account with organization admin access (or personal account)
+- A publicly accessible Apollos AI instance (or a tunnel like ngrok for development)
+
+## Step 1: Create a GitHub App
+
+1. Go to **Settings > Developer settings > GitHub Apps > New GitHub App**
+   - Organization: `https://github.com/organizations/<org>/settings/apps/new`
+   - Personal: `https://github.com/settings/apps/new`
+
+2. Fill in the required fields:
+   - **GitHub App name**: e.g., "Apollos AI Agent"
+   - **Homepage URL**: Your Apollos AI instance URL
+   - **Webhook URL**: `https://<your-domain>/webhook_github`
+   - **Webhook secret**: Generate a strong random secret (save this for Step 3)
+
+3. Set **Permissions**:
+
+   | Permission | Access | Purpose |
+   |-----------|--------|---------|
+   | Issues | Read & Write | Read issues, post comments |
+   | Pull requests | Read & Write | Read PRs, post review comments |
+   | Contents | Read & Write | Read/push code changes |
+   | Metadata | Read-only | Required for all apps |
+
+4. Subscribe to **Events**:
+   - Issues
+   - Issue comment
+   - Pull request
+   - Pull request review comment
+
+5. Set **Where can this GitHub App be installed?** to "Only on this account" (or "Any account" for broader use).
+
+6. Click **Create GitHub App**.
+
+## Step 2: Install the App
+
+1. After creation, click **Install App** in the left sidebar.
+2. Choose the account/organization to install on.
+3. Select repositories: **All repositories** or specific ones.
+4. Click **Install**.
+
+## Step 3: Configure Environment Variables
+
+Add these to your `usr/.env` file (or set via environment):
+
+```bash
+# GitHub webhook secret (from Step 1)
+A0_SET_GITHUB_WEBHOOK_SECRET=your-webhook-secret-here
+
+# GitHub App ID (shown on the app settings page)
+A0_SET_GITHUB_APP_ID=123456
+```
+
+Alternatively, configure via the UI under **Settings > Integrations**.
+
+## Step 4: Enable Integrations
+
+Set the master integration toggle:
+
+```bash
+A0_SET_INTEGRATIONS_ENABLED=true
+```
+
+## How It Works
+
+1. When an issue is opened/labeled or a comment mentions the bot, GitHub sends a webhook to `/webhook_github`.
+2. The webhook handler verifies the signature, extracts the event context, and creates an agent conversation.
+3. The agent processes the request using the GitHub context prompt template.
+4. When the agent completes, the callback extension posts the result as a comment on the originating issue or PR.
+
+## Supported Events
+
+| Event | Trigger | Agent Action |
+|-------|---------|-------------|
+| Issue opened | New issue created | Analyze and respond |
+| Issue labeled | Label added (e.g., "apollos-ai") | Process based on label |
+| Issue comment | Comment with @mention | Respond to request |
+| PR opened | New pull request | Review and comment |
+| PR review requested | Review requested | Perform code review |
+| PR review comment | Comment on PR diff | Respond in thread |
+
+## Development/Testing
+
+For local development, use a tunnel to expose your instance:
+
+```bash
+# Using ngrok
+ngrok http 50080
+
+# Then set webhook URL to: https://<ngrok-id>.ngrok.io/webhook_github
+```
+
+You can also use the GitHub webhook delivery log to replay events for debugging:
+**App Settings > Advanced > Recent Deliveries**
+
+## Troubleshooting
+
+- **403 Invalid signature**: Verify `A0_SET_GITHUB_WEBHOOK_SECRET` matches the webhook secret in GitHub App settings.
+- **Events not arriving**: Check that the app is installed on the repository and the correct events are subscribed.
+- **No agent response**: Ensure `A0_SET_INTEGRATIONS_ENABLED=true` and check the application logs.

--- a/docs/integrations/jira-webhook-setup.md
+++ b/docs/integrations/jira-webhook-setup.md
@@ -1,0 +1,114 @@
+# Jira Webhook Setup Guide
+
+This guide walks through configuring Jira Cloud webhooks to send events to the Apollos AI platform integration.
+
+## Prerequisites
+
+- Jira Cloud project admin access
+- A publicly accessible Apollos AI instance (or a tunnel like ngrok for development)
+
+## Step 1: Generate a Shared Secret
+
+Jira Cloud webhooks use a shared secret passed as a query parameter for authentication. Generate a strong random secret:
+
+```bash
+python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+```
+
+Save this value — you'll use it in both Jira and Apollos AI configuration.
+
+## Step 2: Create the Webhook in Jira
+
+1. Go to **Jira Settings** (gear icon) > **System** > **WebHooks**.
+   - Direct URL: `https://<your-site>.atlassian.net/plugins/servlet/webhooks`
+2. Click **Create a WebHook**.
+3. Fill in:
+   - **Name**: e.g., "Apollos AI Agent"
+   - **URL**: `https://<your-domain>/webhook_jira?secret=<your-shared-secret>`
+   - **Status**: Active
+4. Under **Events**, select:
+
+   | Event | Purpose |
+   |-------|---------|
+   | Issue > created | New issue triggers agent processing |
+   | Issue > updated | Label changes (e.g., adding "apollos-ai") trigger processing |
+   | Comment > created | New comments trigger agent response |
+
+5. Optionally, use the **JQL filter** to scope to specific projects:
+   ```
+   project = MYPROJECT
+   ```
+6. Click **Create**.
+
+## Step 3: Configure Environment Variables
+
+Add these to your `usr/.env` file (or set via environment):
+
+```bash
+# Shared secret (must match the ?secret= parameter in the webhook URL)
+A0_SET_JIRA_WEBHOOK_SECRET=your-shared-secret-here
+
+# Jira site URL (for API callbacks)
+A0_SET_JIRA_SITE_URL=https://your-org.atlassian.net
+```
+
+Alternatively, configure via the UI under **Settings > Integrations**.
+
+## Step 4: Enable Integrations
+
+Set the master integration toggle:
+
+```bash
+A0_SET_INTEGRATIONS_ENABLED=true
+```
+
+## How It Works
+
+1. When a matching event occurs in Jira, it sends a POST to `/webhook_jira?secret=...`.
+2. The webhook handler verifies the shared secret matches the configured value.
+3. For `jira:issue_updated` events, only label changes are processed (to support label-based triggering).
+4. An `IntegrationMessage` is created with the issue context (key, summary, description, priority, status).
+5. The `monologue_end` extension delivers the agent's response as a Jira comment, converting Markdown to Jira wiki markup.
+
+## Supported Events
+
+| Event | Trigger | Agent Action |
+|-------|---------|-------------|
+| `jira:issue_created` | New issue created | Analyze and respond |
+| `jira:issue_updated` | Label added (e.g., "apollos-ai") | Process based on label trigger |
+| `comment_created` | New comment on an issue | Respond to the comment |
+
+## Jira Markup Conversion
+
+The callback extension automatically converts the agent's Markdown response to Jira wiki markup:
+
+| Markdown | Jira Markup |
+|----------|-------------|
+| `**bold**` | `*bold*` |
+| `*italic*` | `_italic_` |
+| `` `code` `` | `{{code}}` |
+| `` ```lang\ncode\n``` `` | `{code:lang}\ncode\n{code}` |
+| `# Heading` | `h1. Heading` |
+| `- item` | `* item` |
+| `1. item` | `# item` |
+| `[text](url)` | `[text\|url]` |
+
+## Development/Testing
+
+For local development, use a tunnel:
+
+```bash
+# Using ngrok
+ngrok http 5000
+
+# Webhook URL: https://<ngrok-id>.ngrok.io/webhook_jira?secret=<your-secret>
+```
+
+You can re-trigger events by making changes in Jira (create an issue, add a comment, toggle a label).
+
+## Troubleshooting
+
+- **403 Invalid signature**: Verify the `?secret=` parameter in the Jira webhook URL matches `A0_SET_JIRA_WEBHOOK_SECRET`.
+- **Events not arriving**: Check the webhook status in Jira Settings > WebHooks. Jira shows delivery logs with HTTP status codes.
+- **Label-based triggers not working**: Only `jira:issue_updated` events with a changelog containing a `labels` field change are processed.
+- **No agent response**: Ensure `A0_SET_INTEGRATIONS_ENABLED=true` and check the application logs.

--- a/docs/integrations/slack-bot-setup.md
+++ b/docs/integrations/slack-bot-setup.md
@@ -1,0 +1,114 @@
+# Slack Bot Setup Guide
+
+This guide walks through creating and configuring a Slack App to receive events for the Apollos AI platform integration.
+
+## Prerequisites
+
+- A Slack workspace where you have admin permissions
+- A publicly accessible Apollos AI instance (or a tunnel like ngrok for development)
+
+## Step 1: Create a Slack App
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) and click **Create New App**.
+2. Choose **From scratch**.
+3. Enter a name (e.g., "Apollos AI") and select your workspace.
+4. Click **Create App**.
+
+## Step 2: Configure OAuth & Permissions
+
+1. In the left sidebar, go to **OAuth & Permissions**.
+2. Under **Bot Token Scopes**, add:
+
+   | Scope | Purpose |
+   |-------|---------|
+   | `app_mentions:read` | Receive @mention events |
+   | `chat:write` | Post responses to channels |
+   | `im:history` | Read direct messages |
+   | `im:read` | Access DM channel info |
+   | `im:write` | Send direct messages |
+
+3. Click **Install to Workspace** and authorize the app.
+4. Copy the **Bot User OAuth Token** (`xoxb-...`) — you'll need this in Step 4.
+
+## Step 3: Enable Events API
+
+1. In the left sidebar, go to **Event Subscriptions**.
+2. Toggle **Enable Events** to On.
+3. Set **Request URL** to: `https://<your-domain>/webhook_slack`
+   - Slack will send a verification challenge; the webhook handler responds automatically.
+4. Under **Subscribe to bot events**, add:
+
+   | Event | Trigger |
+   |-------|---------|
+   | `app_mention` | Someone @mentions your bot in a channel |
+   | `message.im` | Someone sends a direct message to your bot |
+
+5. Click **Save Changes**.
+
+## Step 4: Configure Environment Variables
+
+Add these to your `usr/.env` file (or set via environment):
+
+```bash
+# Slack signing secret (from App Settings > Basic Information > Signing Secret)
+A0_SET_SLACK_SIGNING_SECRET=your-signing-secret-here
+
+# Bot User OAuth Token (from Step 2)
+A0_SET_SLACK_BOT_TOKEN=xoxb-your-bot-token-here
+```
+
+Alternatively, configure via the UI under **Settings > Integrations**.
+
+## Step 5: Enable Integrations
+
+Set the master integration toggle:
+
+```bash
+A0_SET_INTEGRATIONS_ENABLED=true
+```
+
+## How It Works
+
+1. When a user @mentions the bot or sends a DM, Slack sends an `event_callback` to `/webhook_slack`.
+2. The webhook handler verifies the request signature using the signing secret and a timing-based replay attack check.
+3. Duplicate events are filtered using an in-memory dedup cache (5-minute TTL).
+4. Bot messages are ignored to prevent response loops.
+5. An `IntegrationMessage` is created and a callback is registered for when the agent completes.
+6. The `monologue_end` extension delivers the agent's response back to the Slack channel/thread.
+
+## Supported Events
+
+| Event | Trigger | Agent Action |
+|-------|---------|-------------|
+| `app_mention` | @mention in any channel the bot is in | Respond in thread |
+| `message.im` | Direct message to the bot | Respond in DM |
+
+## Identity Linking (Optional)
+
+Users can link their Slack identity to their Apollos AI account via OAuth:
+
+1. The user clicks "Connect Slack" in the UI.
+2. They are redirected to Slack's OAuth consent screen.
+3. After approval, `/webhook_slack_oauth` exchanges the code for tokens and links the identities.
+
+This enables the agent to personalize responses based on the user's internal account context.
+
+## Development/Testing
+
+For local development, use a tunnel to expose your instance:
+
+```bash
+# Using ngrok
+ngrok http 5000
+
+# Then set Request URL to: https://<ngrok-id>.ngrok.io/webhook_slack
+```
+
+You can also use the Slack Events API debugger in your app settings.
+
+## Troubleshooting
+
+- **403 Invalid signature**: Verify `A0_SET_SLACK_SIGNING_SECRET` matches the Signing Secret in your Slack App's Basic Information page.
+- **URL verification failing**: Ensure the webhook endpoint is reachable and returns `{"challenge": "..."}` for `url_verification` requests.
+- **Bot not responding**: Check that the bot is invited to the channel, `A0_SET_INTEGRATIONS_ENABLED=true`, and the bot token has the required scopes.
+- **Duplicate responses**: The handler includes dedup logic, but verify you haven't subscribed to overlapping event types.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -417,6 +417,22 @@ Any UI setting can be overridden via environment variable using the prefix `A0_S
 | `A0_SET_STT_WAITING_TIMEOUT` | Waiting timeout before stop (ms) | `2000` |
 | `A0_SET_TTS_KOKORO` | Use Kokoro TTS engine | `true` |
 
+### Platform Integrations
+
+Enable inbound webhook processing from external platforms (Slack, GitHub, Jira). The agent receives events via platform-specific webhook endpoints, processes them, and delivers responses back through the callback system.
+
+Configure these settings via the UI (**Settings > Integrations**) or environment variables. See `docs/integrations/` for per-platform setup guides.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `A0_SET_INTEGRATIONS_ENABLED` | Master toggle for inbound webhook processing | `false` |
+| `A0_SET_SLACK_SIGNING_SECRET` | Slack App signing secret for webhook verification | *(empty)* |
+| `A0_SET_SLACK_BOT_TOKEN` | Slack Bot User OAuth Token (`xoxb-...`) for posting responses | *(empty)* |
+| `A0_SET_GITHUB_WEBHOOK_SECRET` | GitHub App webhook secret for HMAC-SHA256 signature verification | *(empty)* |
+| `A0_SET_GITHUB_APP_ID` | GitHub App ID (shown on the App settings page) | *(empty)* |
+| `A0_SET_JIRA_WEBHOOK_SECRET` | Shared secret for Jira webhook authentication (passed as `?secret=` query parameter) | *(empty)* |
+| `A0_SET_JIRA_SITE_URL` | Jira Cloud site URL (e.g., `https://your-org.atlassian.net`) for API callbacks | *(empty)* |
+
 ### MCP & A2A Servers
 
 | Variable | Description | Default |

--- a/prompts/integrations/github_context.md
+++ b/prompts/integrations/github_context.md
@@ -1,0 +1,21 @@
+## Integration Context: GitHub
+
+You were triggered by a GitHub event on repository **{{repo_full_name}}**.
+
+**Event type:** {{event_type}}
+**{{issue_or_pr}} #{{number}}:** {{title}}
+
+**Description:**
+{{body}}
+
+{{if comments}}
+**Recent comments:**
+{{comments}}
+{{endif}}
+
+**Instructions:**
+- Address the issue or PR directly
+- If you make code changes, create a PR or push to the relevant branch
+- Your response will be posted as a comment on the {{issue_or_pr}}
+- Use GitHub-flavored markdown
+- Reference related issues/PRs with #number syntax

--- a/prompts/integrations/jira_context.md
+++ b/prompts/integrations/jira_context.md
@@ -1,0 +1,22 @@
+## Integration Context: Jira
+
+You were triggered by a Jira ticket update on **{{jira_site_url}}**.
+
+**Ticket:** {{ticket_key}} — {{ticket_summary}}
+**Status:** {{ticket_status}}
+**Priority:** {{ticket_priority}}
+**Reporter:** {{reporter_name}}
+
+**Description:**
+{{ticket_description}}
+
+{{if comments}}
+**Recent comments:**
+{{comments}}
+{{endif}}
+
+**Instructions:**
+- Address the Jira ticket requirements
+- Your response will be posted as a comment on the ticket
+- If you create code changes, include PR links in your response
+- Note: Jira uses wiki markup, but your response will be auto-converted

--- a/prompts/integrations/slack_context.md
+++ b/prompts/integrations/slack_context.md
@@ -1,0 +1,17 @@
+## Integration Context: Slack
+
+You were triggered by a Slack message from **{{external_user_name}}** in channel **{{channel_id}}**.
+
+**Original message:**
+{{message_text}}
+
+{{if thread_context}}
+**Thread context:**
+{{thread_context}}
+{{endif}}
+
+**Instructions:**
+- Address the user's request directly
+- Keep your response concise — it will be posted back as a Slack thread reply
+- Use markdown formatting (Slack supports bold, italic, code blocks, links)
+- If you need to create files or PRs, do so and include links in your response

--- a/prompts/integrations/summary.md
+++ b/prompts/integrations/summary.md
@@ -1,0 +1,10 @@
+## Summary Request
+
+Please provide a concise summary of what you accomplished in this task. Structure your response as:
+
+1. **What was requested:** One sentence describing the original request
+2. **What was done:** Bullet points of actions taken
+3. **Result:** Current status (completed, partially completed, blocked)
+4. **Links:** Any relevant PRs, commits, or resources created
+
+Keep the summary under 500 words. It will be posted back to the platform that triggered this task.

--- a/python/api/callback_admin.py
+++ b/python/api/callback_admin.py
@@ -1,0 +1,59 @@
+"""Admin API for managing integration callbacks.
+
+Auto-discovered at POST /callback_admin.
+
+Actions:
+- list: List all callbacks with their status
+- retry: Retry a specific failed callback
+"""
+
+from python.helpers.api import ApiHandler, Request
+from python.helpers.callback_registry import CallbackRegistry
+from python.helpers.callback_retry import schedule_retry
+
+
+class CallbackAdmin(ApiHandler):
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["POST"]
+
+    async def process(self, input: dict, request: Request) -> dict:
+        data = request.get_json()
+        action = data.get("action", "")
+        registry = CallbackRegistry.get_instance()
+
+        if action == "list":
+            return self._list_callbacks(registry)
+        elif action == "retry":
+            return self._retry_callback(registry, data.get("conversation_id", ""))
+
+        return {"error": f"Unknown action: {action}"}
+
+    def _list_callbacks(self, registry: CallbackRegistry) -> dict:
+        callbacks = registry.list_all()
+        return {
+            "callbacks": [
+                {
+                    "conversation_id": reg.conversation_id,
+                    "source": reg.webhook_context.source,
+                    "status": reg.status,
+                    "attempts": reg.attempts,
+                    "last_error": reg.last_error,
+                    "created_at": reg.created_at.isoformat(),
+                }
+                for reg in callbacks
+            ]
+        }
+
+    def _retry_callback(self, registry: CallbackRegistry, conversation_id: str) -> dict:
+        if not conversation_id:
+            return {"error": "Missing conversation_id"}
+
+        reg = registry.get(conversation_id)
+        if not reg:
+            return {"error": f"Callback not found: {conversation_id}"}
+
+        result = schedule_retry(registry, conversation_id)
+        if result:
+            return {"ok": True, "message": f"Retry scheduled for {conversation_id}"}
+        return {"ok": False, "message": "Max retry attempts reached"}

--- a/python/api/integration_settings_get.py
+++ b/python/api/integration_settings_get.py
@@ -1,0 +1,29 @@
+"""Integration settings API — returns current platform integration config.
+
+Auto-discovered at GET /integration_settings_get.
+
+Returns integration settings with secrets masked (only boolean flags
+indicating whether secrets are configured, never the actual values).
+"""
+
+from python.helpers.api import ApiHandler, Request
+from python.helpers.settings import get_settings
+
+
+class IntegrationSettingsGet(ApiHandler):
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["GET"]
+
+    async def process(self, input: dict, request: Request) -> dict:
+        settings = get_settings()
+
+        return {
+            "integrations_enabled": bool(settings.get("integrations_enabled", False)),
+            "has_slack_secret": bool(settings.get("slack_signing_secret", "")),
+            "has_slack_token": bool(settings.get("slack_bot_token", "")),
+            "has_github_secret": bool(settings.get("github_webhook_secret", "")),
+            "github_app_id": settings.get("github_app_id", ""),
+            "has_jira_secret": bool(settings.get("jira_webhook_secret", "")),
+            "jira_site_url": settings.get("jira_site_url", ""),
+        }

--- a/python/api/webhook_events_get.py
+++ b/python/api/webhook_events_get.py
@@ -1,0 +1,26 @@
+"""Webhook event log API — returns recent inbound webhook events.
+
+Auto-discovered at GET /webhook_events_get.
+
+Query parameters:
+- limit: Maximum number of events to return (default 50)
+- source: Filter by platform (slack, github, jira)
+"""
+
+from python.helpers.api import ApiHandler, Request
+from python.helpers.webhook_event_log import WebhookEventLog
+
+
+class WebhookEventsGet(ApiHandler):
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["GET"]
+
+    async def process(self, input: dict, request: Request) -> dict:
+        log = WebhookEventLog.get_instance()
+
+        limit = int(request.args.get("limit", "50"))
+        source = request.args.get("source")
+
+        events = log.recent(limit=limit, source=source)
+        return {"events": events}

--- a/python/api/webhook_github.py
+++ b/python/api/webhook_github.py
@@ -1,0 +1,153 @@
+"""GitHub webhook receiver — accepts GitHub App webhook payloads.
+
+Auto-discovered at POST /webhook_github.
+
+Handles:
+- issues (opened, labeled)
+- issue_comment (created with @mention)
+- pull_request (opened, review_requested)
+- pull_request_review_comment (created)
+"""
+
+from flask import Response
+
+from python.helpers.api import ApiHandler, Request
+from python.helpers.integration_models import (
+    CallbackRegistration,
+    IntegrationMessage,
+    SourceType,
+    WebhookContext,
+)
+from python.helpers.print_style import PrintStyle
+from python.helpers.webhook_verify import verify_github_signature
+
+# Events and actions we care about
+_ISSUE_ACTIONS = {"opened", "labeled"}
+_PR_ACTIONS = {"opened", "review_requested"}
+
+
+def _get_github_webhook_secret() -> str:
+    """Retrieve the GitHub webhook secret from settings."""
+    from python.helpers.settings import get_settings
+
+    return get_settings().get("github_webhook_secret", "")
+
+
+class WebhookGithub(ApiHandler):
+    @classmethod
+    def requires_auth(cls) -> bool:
+        return False
+
+    @classmethod
+    def requires_csrf(cls) -> bool:
+        return False
+
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["POST"]
+
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        raw_body = request.data
+        secret = _get_github_webhook_secret()
+
+        if not verify_github_signature(
+            raw_body,
+            request.headers.get("X-Hub-Signature-256"),
+            secret,
+        ):
+            return Response("Invalid signature", status=403)
+
+        data = request.get_json()
+        event_type = request.headers.get("X-GitHub-Event", "")
+        action = data.get("action", "")
+
+        should_process = False
+
+        if event_type == "issues" and action in _ISSUE_ACTIONS:
+            should_process = True
+        elif event_type == "issue_comment" and action == "created":
+            should_process = True
+        elif event_type == "pull_request" and action in _PR_ACTIONS:
+            should_process = True
+        elif event_type == "pull_request_review_comment" and action == "created":
+            should_process = True
+
+        if should_process:
+            await self._process_github_event(event_type, action, data)
+
+        return {"ok": True}
+
+    async def _process_github_event(
+        self, event_type: str, action: str, data: dict
+    ) -> None:
+        """Process a GitHub event by creating an IntegrationMessage."""
+        from python.helpers.callback_registry import CallbackRegistry
+
+        repo = data.get("repository", {}).get("full_name", "")
+
+        # Extract context based on event type
+        if event_type in ("issues", "issue_comment"):
+            issue = data.get("issue", {})
+            number = issue.get("number", 0)
+            title = issue.get("title", "")
+            body = issue.get("body", "")
+            user = issue.get("user", {})
+            item_type = "issue"
+
+            # For comments, include comment body
+            if event_type == "issue_comment":
+                comment = data.get("comment", {})
+                body = comment.get("body", "")
+                user = comment.get("user", {})
+        elif event_type in ("pull_request", "pull_request_review_comment"):
+            pr = data.get("pull_request", {})
+            number = pr.get("number", 0)
+            title = pr.get("title", "")
+            body = pr.get("body", "")
+            user = pr.get("user", {})
+            item_type = "pull_request"
+
+            if event_type == "pull_request_review_comment":
+                comment = data.get("comment", {})
+                body = comment.get("body", "")
+                user = comment.get("user", {})
+        else:
+            return
+
+        message = IntegrationMessage(
+            source=SourceType.GITHUB,
+            text=body or "",
+            external_user_id=str(user.get("id", "")),
+            external_user_name=user.get("login", ""),
+            channel_id=repo,
+            metadata={
+                "event_type": event_type,
+                "action": action,
+                "repo_full_name": repo,
+                "number": number,
+                "title": title,
+                "item_type": item_type,
+            },
+        )
+
+        webhook_ctx = WebhookContext(
+            source=SourceType.GITHUB,
+            channel_id=repo,
+            metadata={
+                "issue_number": number,
+                "event_type": event_type,
+                "item_type": item_type,
+                "delivery_id": "",
+            },
+        )
+
+        callback = CallbackRegistration(
+            conversation_id=f"github:{repo}:{item_type}:{number}",
+            webhook_context=webhook_ctx,
+        )
+        registry = CallbackRegistry.get_instance()
+        registry.register(callback.conversation_id, callback)
+
+        PrintStyle(font_color="cyan", padding=False).print(
+            f"GitHub event: {event_type}/{action} on {repo}#{number}"
+        )

--- a/python/api/webhook_github.py
+++ b/python/api/webhook_github.py
@@ -132,7 +132,7 @@ class WebhookGithub(ApiHandler):
 
         webhook_ctx = WebhookContext(
             source=SourceType.GITHUB,
-            channel_id=repo,
+            channel_id=message.channel_id,
             metadata={
                 "issue_number": number,
                 "event_type": event_type,
@@ -142,7 +142,7 @@ class WebhookGithub(ApiHandler):
         )
 
         callback = CallbackRegistration(
-            conversation_id=f"github:{repo}:{item_type}:{number}",
+            conversation_id=f"github:{message.channel_id}:{item_type}:{number}",
             webhook_context=webhook_ctx,
         )
         registry = CallbackRegistry.get_instance()

--- a/python/api/webhook_jira.py
+++ b/python/api/webhook_jira.py
@@ -1,0 +1,138 @@
+"""Jira Cloud webhook receiver — accepts Jira webhook payloads.
+
+Auto-discovered at POST /webhook_jira.
+
+Handles:
+- jira:issue_created
+- jira:issue_updated (when "apollos-ai" label is added)
+- comment_created
+"""
+
+from flask import Response
+
+from python.helpers.api import ApiHandler, Request
+from python.helpers.integration_models import (
+    CallbackRegistration,
+    IntegrationMessage,
+    SourceType,
+    WebhookContext,
+)
+from python.helpers.print_style import PrintStyle
+from python.helpers.webhook_verify import verify_jira_signature
+
+# Events we care about
+_HANDLED_EVENTS = {"jira:issue_created", "jira:issue_updated", "comment_created"}
+
+
+def _get_jira_webhook_secret() -> str:
+    """Retrieve the Jira webhook secret from settings."""
+    from python.helpers.settings import get_settings
+
+    return get_settings().get("jira_webhook_secret", "")
+
+
+def _has_label_change(data: dict) -> bool:
+    """Check if the changelog contains a label addition."""
+    changelog = data.get("changelog", {})
+    for item in changelog.get("items", []):
+        if item.get("field") == "labels" and item.get("toString"):
+            return True
+    return False
+
+
+class WebhookJira(ApiHandler):
+    @classmethod
+    def requires_auth(cls) -> bool:
+        return False
+
+    @classmethod
+    def requires_csrf(cls) -> bool:
+        return False
+
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["POST"]
+
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        # Jira sends the shared secret as a query parameter
+        provided_secret = request.args.get("secret", "")
+        expected_secret = _get_jira_webhook_secret()
+
+        if not verify_jira_signature(provided_secret, expected_secret):
+            return Response("Invalid signature", status=403)
+
+        data = request.get_json()
+        event_type = data.get("webhookEvent", "")
+
+        should_process = False
+
+        if event_type == "jira:issue_created":
+            should_process = True
+        elif event_type == "jira:issue_updated" and _has_label_change(data):
+            should_process = True
+        elif event_type == "comment_created":
+            should_process = True
+
+        if should_process:
+            await self._process_jira_event(event_type, data)
+
+        return {"ok": True}
+
+    async def _process_jira_event(self, event_type: str, data: dict) -> None:
+        """Process a Jira event by creating an IntegrationMessage."""
+        from python.helpers.callback_registry import CallbackRegistry
+
+        issue = data.get("issue", {})
+        fields = issue.get("fields", {})
+        issue_key = issue.get("key", "")
+
+        # Extract reporter info
+        reporter = fields.get("reporter", {})
+        user_id = reporter.get("accountId", "")
+        user_name = reporter.get("displayName", "")
+
+        # For comments, use the comment author and body
+        if event_type == "comment_created":
+            comment = data.get("comment", {})
+            body = comment.get("body", "")
+            author = comment.get("author", {})
+            user_id = author.get("accountId", "")
+            user_name = author.get("displayName", "")
+        else:
+            body = fields.get("description", "") or ""
+
+        message = IntegrationMessage(
+            source=SourceType.JIRA,
+            text=body,
+            external_user_id=user_id,
+            external_user_name=user_name,
+            channel_id=issue_key.split("-")[0] if "-" in issue_key else issue_key,
+            metadata={
+                "event_type": event_type,
+                "issue_key": issue_key,
+                "summary": fields.get("summary", ""),
+                "priority": fields.get("priority", {}).get("name", ""),
+                "status": fields.get("status", {}).get("name", ""),
+                "issue_type": fields.get("issuetype", {}).get("name", ""),
+            },
+        )
+
+        webhook_ctx = WebhookContext(
+            source=SourceType.JIRA,
+            channel_id=message.channel_id,
+            metadata={
+                "issue_key": issue_key,
+                "event_type": event_type,
+            },
+        )
+
+        callback = CallbackRegistration(
+            conversation_id=f"jira:{issue_key}",
+            webhook_context=webhook_ctx,
+        )
+        registry = CallbackRegistry.get_instance()
+        registry.register(callback.conversation_id, callback)
+
+        PrintStyle(font_color="cyan", padding=False).print(
+            f"Jira event: {event_type} on {issue_key}"
+        )

--- a/python/api/webhook_slack.py
+++ b/python/api/webhook_slack.py
@@ -1,0 +1,148 @@
+"""Slack webhook receiver — accepts Slack Events API payloads.
+
+Auto-discovered at POST /webhook_slack.
+
+Handles:
+- url_verification (Slack app setup challenge)
+- event_callback with app_mention or DM messages
+"""
+
+import time
+
+from flask import Response
+from python.helpers.integration_models import (
+    CallbackRegistration,
+    IntegrationMessage,
+    SourceType,
+    WebhookContext,
+)
+from python.helpers.webhook_verify import verify_slack_signature
+
+from python.helpers.api import ApiHandler, Request
+from python.helpers.print_style import PrintStyle
+
+# Simple in-memory dedup cache: event_id -> timestamp
+# Entries expire after _DEDUP_TTL_SECONDS
+_event_dedup_cache: dict[str, float] = {}
+_DEDUP_TTL_SECONDS = 300  # 5 minutes
+
+
+def _get_slack_signing_secret() -> str:
+    """Retrieve the Slack signing secret from settings."""
+    from python.helpers.settings import get_settings
+
+    return get_settings().get("slack_signing_secret", "")
+
+
+def _is_duplicate_event(event_id: str) -> bool:
+    """Check if we've already processed this event (and prune stale entries)."""
+    now = time.time()
+    # Prune expired entries
+    expired = [k for k, v in _event_dedup_cache.items() if now - v > _DEDUP_TTL_SECONDS]
+    for k in expired:
+        del _event_dedup_cache[k]
+
+    if event_id in _event_dedup_cache:
+        return True
+    _event_dedup_cache[event_id] = now
+    return False
+
+
+class WebhookSlack(ApiHandler):
+    @classmethod
+    def requires_auth(cls) -> bool:
+        return False
+
+    @classmethod
+    def requires_csrf(cls) -> bool:
+        return False
+
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["POST"]
+
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        raw_body = request.data
+        signing_secret = _get_slack_signing_secret()
+
+        # Verify Slack signature
+        if not verify_slack_signature(
+            raw_body,
+            request.headers.get("X-Slack-Signature"),
+            request.headers.get("X-Slack-Request-Timestamp"),
+            signing_secret,
+        ):
+            return Response("Invalid signature", status=403)
+
+        data = request.get_json()
+
+        # Handle URL verification challenge (Slack app setup)
+        if data.get("type") == "url_verification":
+            return {"challenge": data["challenge"]}
+
+        # Handle event callbacks
+        if data.get("type") == "event_callback":
+            event = data.get("event", {})
+            event_id = data.get("event_id", "")
+
+            # Dedup: skip if we've already processed this event
+            if event_id and _is_duplicate_event(event_id):
+                PrintStyle(font_color="cyan", padding=False).print(
+                    f"Slack: duplicate event {event_id}, skipping"
+                )
+                return {"ok": True}
+
+            # Ignore bot messages to prevent loops
+            if event.get("bot_id") or event.get("subtype") == "bot_message":
+                return {"ok": True}
+
+            # Process app_mention or DM messages
+            event_type = event.get("type", "")
+            if event_type == "app_mention" or (
+                event_type == "message" and event.get("channel_type") == "im"
+            ):
+                await self._process_slack_event(event, data)
+
+        return {"ok": True}
+
+    async def _process_slack_event(self, event: dict, data: dict) -> None:
+        """Process a Slack event by creating an IntegrationMessage and routing to agent."""
+        from python.helpers.callback_registry import CallbackRegistry
+
+        message = IntegrationMessage(
+            source=SourceType.SLACK,
+            text=event.get("text", ""),
+            external_user_id=event.get("user", ""),
+            external_message_id=event.get("ts", ""),
+            thread_id=event.get("thread_ts", event.get("ts", "")),
+            channel_id=event.get("channel", ""),
+            metadata={
+                "team_id": data.get("team_id", ""),
+                "event_type": event.get("type", ""),
+            },
+        )
+
+        webhook_ctx = WebhookContext(
+            source=SourceType.SLACK,
+            channel_id=message.channel_id,
+            thread_id=message.thread_id,
+            team_id=data.get("team_id"),
+            metadata={"event_id": data.get("event_id", "")},
+        )
+
+        # Register callback for when agent completes
+        callback = CallbackRegistration(
+            conversation_id=f"slack:{message.channel_id}:{message.thread_id}",
+            webhook_context=webhook_ctx,
+        )
+        registry = CallbackRegistry.get_instance()
+        registry.register(callback.conversation_id, callback)
+
+        PrintStyle(font_color="cyan", padding=False).print(
+            f"Slack event received: type={event.get('type')}, "
+            f"channel={message.channel_id}, user={message.external_user_id}"
+        )
+
+        # Agent routing will be wired in when the full message loop
+        # integration is implemented. For now, the callback is registered
+        # and will be picked up by the monologue_end extension.

--- a/python/api/webhook_slack_oauth.py
+++ b/python/api/webhook_slack_oauth.py
@@ -1,0 +1,111 @@
+"""Slack OAuth callback handler — links Slack users to internal accounts.
+
+Auto-discovered at GET /webhook_slack_oauth.
+
+OAuth2 flow:
+1. User clicks "Connect Slack" in the UI
+2. Redirected to Slack OAuth consent
+3. Slack redirects back here with a code
+4. We exchange the code for tokens and link the identity
+"""
+
+import httpx
+
+from python.helpers.api import ApiHandler, Request, Response, session
+from python.helpers.print_style import PrintStyle
+
+
+def _get_slack_credentials() -> tuple[str, str]:
+    """Retrieve Slack OAuth credentials from settings."""
+    from python.helpers.settings import get_settings
+
+    settings = get_settings()
+    client_id = settings.get("slack_app_id", "")
+    client_secret = settings.get("slack_signing_secret", "")
+    return client_id, client_secret
+
+
+def _exchange_slack_code(code: str) -> dict:
+    """Exchange an OAuth code for Slack access tokens."""
+    client_id, client_secret = _get_slack_credentials()
+    resp = httpx.post(
+        "https://slack.com/api/oauth.v2.access",
+        data={
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "code": code,
+        },
+    )
+    return resp.json()
+
+
+def _link_slack_user(
+    internal_user_id: str,
+    slack_user_id: str,
+    team_id: str,
+    access_token: str,
+) -> None:
+    """Link a Slack user to an internal user account."""
+    from python.helpers.auth_db import get_session
+    from python.helpers.user_store import link_external_identity
+
+    with get_session() as db:
+        link_external_identity(
+            db,
+            user_id=internal_user_id,
+            platform="slack",
+            external_user_id=slack_user_id,
+            external_display_name=None,
+            external_team_id=team_id,
+        )
+        db.commit()
+
+    PrintStyle(font_color="cyan", padding=False).print(
+        f"Linked Slack user {slack_user_id} to internal user {internal_user_id}"
+    )
+
+
+class WebhookSlackOauth(ApiHandler):
+    @classmethod
+    def requires_csrf(cls) -> bool:
+        return False
+
+    @classmethod
+    def get_methods(cls) -> list[str]:
+        return ["GET"]
+
+    async def process(self, input: dict, request: Request) -> dict | Response:
+        code = request.args.get("code")
+        if not code:
+            return {"error": "Missing OAuth code parameter"}
+
+        # Exchange code for tokens
+        oauth_response = _exchange_slack_code(code)
+
+        if not oauth_response.get("ok"):
+            error = oauth_response.get("error", "unknown_error")
+            PrintStyle(font_color="red", padding=False).print(
+                f"Slack OAuth failed: {error}"
+            )
+            return {"error": f"Slack OAuth failed: {error}"}
+
+        # Extract user and team info
+        slack_user_id = oauth_response.get("authed_user", {}).get("id", "")
+        team = oauth_response.get("team", {})
+        team_id = team.get("id", "")
+        access_token = oauth_response.get("access_token", "")
+
+        # Get the internal user from the session
+        user = session.get("user")
+        if not user:
+            return {"error": "Not authenticated — log in first"}
+
+        internal_user_id = user.get("id", "")
+
+        # Link the Slack identity to the internal user
+        _link_slack_user(internal_user_id, slack_user_id, team_id, access_token)
+
+        return {
+            "ok": True,
+            "message": f"Slack account linked successfully (team: {team.get('name', team_id)})",
+        }

--- a/python/extensions/monologue_end/_80_integration_callback.py
+++ b/python/extensions/monologue_end/_80_integration_callback.py
@@ -1,0 +1,63 @@
+"""Fire integration callbacks when the agent's monologue completes.
+
+Checks the CallbackRegistry for a pending callback matching this
+conversation. If found, marks it PROCESSING and schedules delivery
+back to the originating platform via MCP tools.
+"""
+
+from agent import LoopData
+from python.helpers.callback_registry import CallbackRegistry
+from python.helpers.extension import Extension
+from python.helpers.integration_models import CallbackStatus
+from python.helpers.log import Log
+
+
+class IntegrationCallback(Extension):
+    async def execute(self, loop_data: LoopData = LoopData(), **kwargs):
+        # Only fire for the main agent (agent 0), not subordinates
+        if self.agent.number != 0:
+            return
+
+        registry = CallbackRegistry.get_instance()
+        reg = registry.get(self.agent.context.id)
+        if not reg or reg.status != CallbackStatus.PENDING:
+            return
+
+        # Mark as processing to prevent duplicate delivery
+        registry.update_status(self.agent.context.id, CallbackStatus.PROCESSING)
+
+        try:
+            await self._deliver_callback(reg, loop_data)
+            registry.update_status(self.agent.context.id, CallbackStatus.COMPLETED)
+        except Exception as e:
+            registry.increment_attempts(self.agent.context.id, error=str(e))
+            registry.update_status(self.agent.context.id, CallbackStatus.ERROR)
+            Log.error(f"Integration callback failed for {self.agent.context.id}: {e}")
+
+    async def _deliver_callback(self, reg, loop_data):
+        """Deliver the callback to the originating platform.
+
+        This is a dispatcher -- routes to the appropriate platform-specific
+        delivery method. Platform integrations (Phase 2-4) will implement
+        the actual MCP tool calls.
+        """
+        source = reg.webhook_context.source
+        summary = self._extract_summary(loop_data)
+
+        # Platform-specific delivery will be added in Phase 2-4
+        # For now, log the callback
+        Log.info(
+            f"Integration callback ready: source={source}, "
+            f"conversation={reg.conversation_id}, "
+            f"summary_length={len(summary)}"
+        )
+
+    def _extract_summary(self, loop_data) -> str:
+        """Extract a summary from the agent's last response."""
+        if hasattr(self.agent, "history") and self.agent.history:
+            for msg in reversed(self.agent.history):
+                if hasattr(msg, "role") and msg.role == "assistant":
+                    content = getattr(msg, "content", "")
+                    if isinstance(content, str) and content.strip():
+                        return content[:4000]
+        return "Agent completed the task."

--- a/python/helpers/callback_registry.py
+++ b/python/helpers/callback_registry.py
@@ -1,0 +1,70 @@
+"""Thread-safe in-memory registry for integration callback tracking.
+
+Stores CallbackRegistration objects keyed by conversation_id. When an
+agent monologue completes, the monologue_end extension checks this
+registry and fires the appropriate callback processor.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import ClassVar
+
+from python.helpers.integration_models import (
+    CallbackRegistration,
+    CallbackStatus,
+)
+
+
+class CallbackRegistry:
+    """Thread-safe registry for pending integration callbacks."""
+
+    _instance: ClassVar[CallbackRegistry | None] = None
+    _lock: ClassVar[threading.Lock] = threading.Lock()
+
+    def __init__(self) -> None:
+        self._store: dict[str, CallbackRegistration] = {}
+        self._store_lock = threading.Lock()
+
+    @classmethod
+    def get_instance(cls) -> CallbackRegistry:
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    def register(
+        self, conversation_id: str, registration: CallbackRegistration
+    ) -> None:
+        with self._store_lock:
+            self._store[conversation_id] = registration
+
+    def get(self, conversation_id: str) -> CallbackRegistration | None:
+        with self._store_lock:
+            return self._store.get(conversation_id)
+
+    def update_status(self, conversation_id: str, status: CallbackStatus) -> None:
+        with self._store_lock:
+            reg = self._store.get(conversation_id)
+            if reg:
+                reg.status = status
+
+    def increment_attempts(
+        self, conversation_id: str, error: str | None = None
+    ) -> None:
+        with self._store_lock:
+            reg = self._store.get(conversation_id)
+            if reg:
+                reg.attempts += 1
+                reg.last_error = error
+
+    def remove(self, conversation_id: str) -> None:
+        with self._store_lock:
+            self._store.pop(conversation_id, None)
+
+    def list_pending(self) -> list[CallbackRegistration]:
+        with self._store_lock:
+            return [
+                r for r in self._store.values() if r.status == CallbackStatus.PENDING
+            ]

--- a/python/helpers/callback_registry.py
+++ b/python/helpers/callback_registry.py
@@ -68,3 +68,15 @@ class CallbackRegistry:
             return [
                 r for r in self._store.values() if r.status == CallbackStatus.PENDING
             ]
+
+    def list_awaiting_approval(self) -> list[CallbackRegistration]:
+        with self._store_lock:
+            return [
+                r
+                for r in self._store.values()
+                if r.status == CallbackStatus.AWAITING_APPROVAL
+            ]
+
+    def list_all(self) -> list[CallbackRegistration]:
+        with self._store_lock:
+            return list(self._store.values())

--- a/python/helpers/callback_retry.py
+++ b/python/helpers/callback_retry.py
@@ -1,0 +1,41 @@
+"""Retry logic for failed integration callback deliveries.
+
+Provides exponential backoff scheduling and a maximum retry limit.
+When a callback fails, schedule_retry() resets it to PENDING status
+so the monologue_end extension will re-attempt delivery.
+"""
+
+from __future__ import annotations
+
+from python.helpers.callback_registry import CallbackRegistry
+from python.helpers.integration_models import CallbackStatus
+
+MAX_RETRY_ATTEMPTS = 3
+BASE_DELAY_SECONDS = 2
+MAX_DELAY_SECONDS = 300  # 5 minutes
+
+
+def get_backoff_delay(attempt: int) -> float:
+    """Calculate exponential backoff delay for the given attempt number.
+
+    Uses 2^attempt as the base, capped at MAX_DELAY_SECONDS.
+    """
+    delay = BASE_DELAY_SECONDS**attempt
+    return min(delay, MAX_DELAY_SECONDS)
+
+
+def schedule_retry(registry: CallbackRegistry, conversation_id: str) -> bool:
+    """Schedule a retry for a failed callback.
+
+    Returns True if the retry was scheduled, False if max attempts reached.
+    """
+    reg = registry.get(conversation_id)
+    if not reg:
+        return False
+
+    if reg.attempts >= MAX_RETRY_ATTEMPTS:
+        return False
+
+    # Reset to PENDING so the extension picks it up again
+    registry.update_status(conversation_id, CallbackStatus.PENDING)
+    return True

--- a/python/helpers/integration_models.py
+++ b/python/helpers/integration_models.py
@@ -1,0 +1,67 @@
+"""Shared models for platform integrations (Slack, GitHub, Jira).
+
+Defines the normalized message format, webhook context, and callback
+registration used by all webhook handlers and the callback processor.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class SourceType(StrEnum):
+    SLACK = "slack"
+    GITHUB = "github"
+    JIRA = "jira"
+    INTERNAL = "internal"
+
+
+class IntegrationMessage(BaseModel):
+    """Normalized inbound message from any platform."""
+
+    source: SourceType
+    text: str
+    external_user_id: str
+    external_user_name: str | None = None
+    external_message_id: str | None = None
+    thread_id: str | None = None
+    channel_id: str | None = None
+    metadata: dict = Field(default_factory=dict)
+    received_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class WebhookContext(BaseModel):
+    """Captures where a webhook came from so callbacks can reply."""
+
+    source: SourceType
+    channel_id: str | None = None
+    thread_id: str | None = None
+    team_id: str | None = None
+    response_url: str | None = None
+    metadata: dict = Field(default_factory=dict)
+
+    def callback_key(self) -> str:
+        """Stable key for deduplication and lookup."""
+        parts = [self.source, self.channel_id or "", self.thread_id or ""]
+        return ":".join(parts)
+
+
+class CallbackStatus(StrEnum):
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    ERROR = "error"
+
+
+class CallbackRegistration(BaseModel):
+    """Tracks a pending callback delivery for a conversation."""
+
+    conversation_id: str
+    webhook_context: WebhookContext
+    status: CallbackStatus = CallbackStatus.PENDING
+    attempts: int = 0
+    last_error: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/python/helpers/integration_models.py
+++ b/python/helpers/integration_models.py
@@ -54,6 +54,7 @@ class CallbackStatus(StrEnum):
     PROCESSING = "processing"
     COMPLETED = "completed"
     ERROR = "error"
+    AWAITING_APPROVAL = "awaiting_approval"
 
 
 class CallbackRegistration(BaseModel):

--- a/python/helpers/jira_markup.py
+++ b/python/helpers/jira_markup.py
@@ -1,0 +1,153 @@
+"""Markdown-to-Jira wiki markup converter.
+
+Converts the agent's Markdown output to Jira wiki markup format.
+Jira Cloud uses its own wiki syntax that differs from standard Markdown.
+
+Conversions:
+- Headers: `# H1` → `h1. H1`
+- Bold: `**text**` → `*text*`
+- Italic: `*text*` → `_text_`
+- Inline code: `` `code` `` → `{{code}}`
+- Strikethrough: `~~text~~` → `-text-`
+- Links: `[text](url)` → `[text|url]`
+- Code blocks: ``` → {code} / {code:lang}
+- Unordered lists: `- item` → `* item`
+- Ordered lists: `1. item` → `# item`
+- Blockquotes: `> text` → `{quote}text{quote}`
+- Horizontal rules: `---` → `----`
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def markdown_to_jira(text: str) -> str:
+    """Convert Markdown text to Jira wiki markup.
+
+    Args:
+        text: Markdown-formatted string.
+
+    Returns:
+        Jira wiki markup string.
+    """
+    if not text:
+        return ""
+
+    # Process code blocks first (before any inline processing)
+    text = _convert_code_blocks(text)
+
+    lines = text.split("\n")
+    result: list[str] = []
+    in_quote = False
+
+    for line in lines:
+        # Skip lines inside code blocks (already processed)
+        if line.startswith("{code") or line == "{code}":
+            if in_quote:
+                result.append("{quote}")
+                in_quote = False
+            result.append(line)
+            continue
+
+        # Blockquotes
+        if line.startswith("> "):
+            if not in_quote:
+                result.append("{quote}")
+                in_quote = True
+            result.append(line[2:])
+            continue
+        elif in_quote:
+            result.append("{quote}")
+            in_quote = False
+
+        # Horizontal rules
+        if re.match(r"^-{3,}$", line.strip()):
+            result.append("----")
+            continue
+
+        # Headers
+        header_match = re.match(r"^(#{1,6})\s+(.+)$", line)
+        if header_match:
+            level = len(header_match.group(1))
+            result.append(f"h{level}. {header_match.group(2)}")
+            continue
+
+        # Unordered lists
+        list_match = re.match(r"^(\s*)[-*+]\s+(.+)$", line)
+        if list_match:
+            result.append(f"* {list_match.group(2)}")
+            continue
+
+        # Ordered lists
+        ol_match = re.match(r"^(\s*)\d+\.\s+(.+)$", line)
+        if ol_match:
+            result.append(f"# {ol_match.group(2)}")
+            continue
+
+        result.append(line)
+
+    # Close any open blockquote
+    if in_quote:
+        result.append("{quote}")
+
+    # Apply inline formatting to the joined result
+    output = "\n".join(result)
+    output = _convert_inline_formatting(output)
+    return output
+
+
+def _convert_code_blocks(text: str) -> str:
+    """Convert fenced code blocks to Jira {code} blocks."""
+
+    def _replace_code_block(match: re.Match) -> str:
+        lang = match.group(1) or ""
+        code = match.group(2)
+        if lang:
+            return f"{{code:{lang}}}\n{code}\n{{code}}"
+        return f"{{code}}\n{code}\n{{code}}"
+
+    return re.sub(
+        r"```(\w*)\n(.*?)```",
+        _replace_code_block,
+        text,
+        flags=re.DOTALL,
+    )
+
+
+def _convert_inline_formatting(text: str) -> str:
+    """Convert inline Markdown formatting to Jira equivalents.
+
+    Order matters: process longer/more-specific patterns first.
+    """
+    # Protect code blocks from inline processing
+    code_blocks: list[str] = []
+
+    def _save_code_block(match: re.Match) -> str:
+        code_blocks.append(match.group(0))
+        return f"\x00CODE{len(code_blocks) - 1}\x00"
+
+    text = re.sub(
+        r"\{code(?::\w+)?\}.*?\{code\}", _save_code_block, text, flags=re.DOTALL
+    )
+
+    # Inline code: `code` → {{code}} (must be before bold/italic)
+    text = re.sub(r"`([^`]+)`", r"{{\1}}", text)
+
+    # Strikethrough: ~~text~~ → -text-
+    text = re.sub(r"~~(.+?)~~", r"-\1-", text)
+
+    # Italic first: *text* → _text_ (single asterisk, not part of **)
+    text = re.sub(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)", r"_\1_", text)
+
+    # Bold: **text** → *text*
+    text = re.sub(r"\*\*(.+?)\*\*", r"*\1*", text)
+
+    # Links: [text](url) → [text|url]
+    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"[\1|\2]", text)
+
+    # Restore code blocks
+    for i, block in enumerate(code_blocks):
+        text = text.replace(f"\x00CODE{i}\x00", block)
+
+    return text

--- a/python/helpers/settings.py
+++ b/python/helpers/settings.py
@@ -170,6 +170,15 @@ class Settings(TypedDict):
 
     update_check_enabled: bool
 
+    # Platform integrations
+    integrations_enabled: bool
+    slack_signing_secret: str
+    slack_bot_token: str
+    github_webhook_secret: str
+    github_app_id: str
+    jira_webhook_secret: str
+    jira_site_url: str
+
 
 class PartialSettings(Settings, total=False):
     pass
@@ -772,6 +781,14 @@ def get_default_settings() -> Settings:
         secrets="",
         litellm_global_kwargs=get_default_value("litellm_global_kwargs", {}),
         update_check_enabled=get_default_value("update_check_enabled", True),
+        # Platform integrations
+        integrations_enabled=get_default_value("integrations_enabled", False),
+        slack_signing_secret=get_default_value("slack_signing_secret", ""),
+        slack_bot_token=get_default_value("slack_bot_token", ""),
+        github_webhook_secret=get_default_value("github_webhook_secret", ""),
+        github_app_id=get_default_value("github_app_id", ""),
+        jira_webhook_secret=get_default_value("jira_webhook_secret", ""),
+        jira_site_url=get_default_value("jira_site_url", ""),
     )
 
 

--- a/python/helpers/webhook_event_log.py
+++ b/python/helpers/webhook_event_log.py
@@ -1,0 +1,74 @@
+"""Lightweight in-memory webhook event log for debugging and audit.
+
+Stores recent inbound webhook events in a bounded deque. Events are
+stored as dicts with source, event type, action, delivery ID, and
+optional payload summary.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import deque
+from datetime import datetime, timezone
+from typing import ClassVar
+
+
+class WebhookEventLog:
+    """Bounded in-memory log of recent webhook events."""
+
+    _instance: ClassVar[WebhookEventLog | None] = None
+    _lock: ClassVar[threading.Lock] = threading.Lock()
+
+    def __init__(self, max_entries: int = 1000) -> None:
+        self._events: deque[dict] = deque(maxlen=max_entries)
+        self._store_lock = threading.Lock()
+
+    @classmethod
+    def get_instance(cls) -> WebhookEventLog:
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    def record(
+        self,
+        source: str,
+        event_type: str,
+        action: str = "",
+        delivery_id: str = "",
+        payload_summary: dict | None = None,
+    ) -> None:
+        """Record an inbound webhook event."""
+        event = {
+            "source": source,
+            "event_type": event_type,
+            "action": action,
+            "delivery_id": delivery_id,
+            "payload_summary": payload_summary or {},
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        with self._store_lock:
+            self._events.append(event)
+
+    def recent(
+        self,
+        limit: int = 50,
+        source: str | None = None,
+    ) -> list[dict]:
+        """Return recent events, newest first.
+
+        Args:
+            limit: Maximum number of events to return.
+            source: Optional filter by source platform.
+        """
+        with self._store_lock:
+            events = list(self._events)
+
+        # Newest first
+        events.reverse()
+
+        if source:
+            events = [e for e in events if e["source"] == source]
+
+        return events[:limit]

--- a/python/helpers/webhook_verify.py
+++ b/python/helpers/webhook_verify.py
@@ -1,0 +1,74 @@
+"""Webhook signature verification for external platforms.
+
+Each platform uses a different signing mechanism:
+- GitHub: HMAC-SHA256 of body with webhook secret, prefixed "sha256="
+- Slack: HMAC-SHA256 of "v0:{timestamp}:{body}" with signing secret, prefixed "v0="
+- Jira: Shared secret comparison (Jira Cloud webhook authentication)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+
+
+def verify_github_signature(body: bytes, signature: str | None, secret: str) -> bool:
+    """Verify GitHub webhook HMAC-SHA256 signature.
+
+    Args:
+        body: Raw request body bytes.
+        signature: X-Hub-Signature-256 header value (e.g. "sha256=abc...").
+        secret: Webhook secret configured in GitHub App.
+    """
+    if not signature or not signature.startswith("sha256="):
+        return False
+    expected = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(signature, expected)
+
+
+def verify_slack_signature(
+    body: bytes,
+    signature: str | None,
+    timestamp: str | None,
+    secret: str,
+    *,
+    max_age_seconds: int = 300,
+) -> bool:
+    """Verify Slack request signing secret.
+
+    Args:
+        body: Raw request body bytes.
+        signature: X-Slack-Signature header value (e.g. "v0=abc...").
+        timestamp: X-Slack-Request-Timestamp header value.
+        secret: Slack app signing secret.
+        max_age_seconds: Maximum age of request (default 5 minutes).
+    """
+    if not signature or not timestamp:
+        return False
+    try:
+        ts = int(timestamp)
+    except (ValueError, TypeError):
+        return False
+    if abs(time.time() - ts) > max_age_seconds:
+        return False
+    sig_basestring = f"v0:{timestamp}:{body.decode()}".encode()
+    expected = (
+        "v0=" + hmac.new(secret.encode(), sig_basestring, hashlib.sha256).hexdigest()
+    )
+    return hmac.compare_digest(signature, expected)
+
+
+def verify_jira_signature(provided_secret: str | None, expected_secret: str) -> bool:
+    """Verify Jira Cloud webhook shared secret.
+
+    Jira Cloud webhooks include a shared secret in the request
+    (via query parameter or header) that must match the configured value.
+
+    Args:
+        provided_secret: Secret from the incoming request.
+        expected_secret: Secret configured when the webhook was registered.
+    """
+    if not provided_secret:
+        return False
+    return hmac.compare_digest(provided_secret, expected_secret)

--- a/tests/test_callback_registry.py
+++ b/tests/test_callback_registry.py
@@ -1,0 +1,109 @@
+# tests/test_callback_registry.py
+"""Tests for the callback registry."""
+
+
+class TestCallbackRegistry:
+    def test_register_and_get(self):
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            CallbackStatus,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        ctx = WebhookContext(source=SourceType.SLACK, channel_id="C1", thread_id="t1")
+        reg = CallbackRegistration(conversation_id="conv-1", webhook_context=ctx)
+        registry.register("conv-1", reg)
+
+        result = registry.get("conv-1")
+        assert result is not None
+        assert result.conversation_id == "conv-1"
+        assert result.status == CallbackStatus.PENDING
+
+    def test_get_missing_returns_none(self):
+        from python.helpers.callback_registry import CallbackRegistry
+
+        registry = CallbackRegistry()
+        assert registry.get("nonexistent") is None
+
+    def test_update_status(self):
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            CallbackStatus,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        ctx = WebhookContext(source=SourceType.GITHUB, channel_id="repo")
+        reg = CallbackRegistration(conversation_id="conv-2", webhook_context=ctx)
+        registry.register("conv-2", reg)
+
+        registry.update_status("conv-2", CallbackStatus.COMPLETED)
+        result = registry.get("conv-2")
+        assert result.status == CallbackStatus.COMPLETED
+
+    def test_remove(self):
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        ctx = WebhookContext(source=SourceType.JIRA, channel_id="PROJ")
+        reg = CallbackRegistration(conversation_id="conv-3", webhook_context=ctx)
+        registry.register("conv-3", reg)
+
+        registry.remove("conv-3")
+        assert registry.get("conv-3") is None
+
+    def test_list_pending(self):
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            CallbackStatus,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        for i in range(3):
+            ctx = WebhookContext(source=SourceType.SLACK, channel_id=f"C{i}")
+            reg = CallbackRegistration(conversation_id=f"conv-{i}", webhook_context=ctx)
+            registry.register(f"conv-{i}", reg)
+
+        registry.update_status("conv-1", CallbackStatus.COMPLETED)
+
+        pending = registry.list_pending()
+        assert len(pending) == 2
+        assert all(r.status == CallbackStatus.PENDING for r in pending)
+
+    def test_singleton(self):
+        from python.helpers.callback_registry import CallbackRegistry
+
+        a = CallbackRegistry.get_instance()
+        b = CallbackRegistry.get_instance()
+        assert a is b
+
+    def test_increment_attempts(self):
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        ctx = WebhookContext(source=SourceType.SLACK, channel_id="C1")
+        reg = CallbackRegistration(conversation_id="conv-4", webhook_context=ctx)
+        registry.register("conv-4", reg)
+
+        registry.increment_attempts("conv-4", error="timeout")
+        result = registry.get("conv-4")
+        assert result.attempts == 1
+        assert result.last_error == "timeout"

--- a/tests/test_callback_retry.py
+++ b/tests/test_callback_retry.py
@@ -1,0 +1,187 @@
+# tests/test_callback_retry.py
+"""Tests for callback retry logic with exponential backoff."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestRetryHelperImport:
+    def test_module_importable(self):
+        from python.helpers.callback_retry import schedule_retry
+
+        assert callable(schedule_retry)
+
+
+class TestRetryLogic:
+    def test_max_attempts_default(self):
+        from python.helpers.callback_retry import MAX_RETRY_ATTEMPTS
+
+        assert MAX_RETRY_ATTEMPTS == 3
+
+    def test_backoff_delay_increases(self):
+        from python.helpers.callback_retry import get_backoff_delay
+
+        delay_1 = get_backoff_delay(attempt=1)
+        delay_2 = get_backoff_delay(attempt=2)
+        delay_3 = get_backoff_delay(attempt=3)
+
+        assert delay_1 < delay_2 < delay_3
+
+    def test_backoff_delay_first_attempt(self):
+        from python.helpers.callback_retry import get_backoff_delay
+
+        # First attempt should have a base delay
+        delay = get_backoff_delay(attempt=1)
+        assert delay >= 1  # at least 1 second
+
+    def test_backoff_delay_capped(self):
+        from python.helpers.callback_retry import get_backoff_delay
+
+        # Even large attempt numbers should be capped
+        delay = get_backoff_delay(attempt=100)
+        assert delay <= 300  # max 5 minutes
+
+
+class TestRetryScheduling:
+    @pytest.mark.asyncio
+    async def test_schedule_retry_increments_attempts(self):
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.callback_retry import schedule_retry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            CallbackStatus,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        ctx = WebhookContext(source=SourceType.SLACK, channel_id="C123")
+        reg = CallbackRegistration(
+            conversation_id="retry-test-1",
+            webhook_context=ctx,
+            status=CallbackStatus.ERROR,
+            attempts=1,
+            last_error="Connection timeout",
+        )
+        registry.register("retry-test-1", reg)
+
+        # schedule_retry should mark as PENDING for retry
+        schedule_retry(registry, "retry-test-1")
+
+        updated = registry.get("retry-test-1")
+        assert updated is not None
+        assert updated.status == CallbackStatus.PENDING
+
+    @pytest.mark.asyncio
+    async def test_schedule_retry_does_not_retry_past_max(self):
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.callback_retry import MAX_RETRY_ATTEMPTS, schedule_retry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            CallbackStatus,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        ctx = WebhookContext(source=SourceType.SLACK, channel_id="C123")
+        reg = CallbackRegistration(
+            conversation_id="retry-test-max",
+            webhook_context=ctx,
+            status=CallbackStatus.ERROR,
+            attempts=MAX_RETRY_ATTEMPTS,
+            last_error="Permanent failure",
+        )
+        registry.register("retry-test-max", reg)
+
+        # Should NOT retry — already at max
+        result = schedule_retry(registry, "retry-test-max")
+        assert result is False
+
+        updated = registry.get("retry-test-max")
+        assert updated is not None
+        assert updated.status == CallbackStatus.ERROR
+
+
+class TestCallbackRetryAdminApi:
+    def test_admin_api_importable(self):
+        from python.api.callback_admin import CallbackAdmin
+
+        assert CallbackAdmin is not None
+
+    @pytest.mark.asyncio
+    async def test_list_action_returns_all_callbacks(self):
+        from python.api.callback_admin import CallbackAdmin
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            CallbackStatus,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        ctx = WebhookContext(source=SourceType.GITHUB, channel_id="owner/repo")
+        reg = CallbackRegistration(
+            conversation_id="admin-list-1",
+            webhook_context=ctx,
+            status=CallbackStatus.ERROR,
+            attempts=2,
+            last_error="Failed",
+        )
+        registry.register("admin-list-1", reg)
+
+        handler = CallbackAdmin(MagicMock(), MagicMock())
+        request = MagicMock()
+        request.get_json.return_value = {"action": "list"}
+
+        with patch(
+            "python.api.callback_admin.CallbackRegistry.get_instance",
+            return_value=registry,
+        ):
+            result = await handler.process({}, request)
+
+        assert "callbacks" in result
+        assert len(result["callbacks"]) == 1
+        assert result["callbacks"][0]["conversation_id"] == "admin-list-1"
+
+    @pytest.mark.asyncio
+    async def test_retry_action_retries_failed_callback(self):
+        from python.api.callback_admin import CallbackAdmin
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            CallbackStatus,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        ctx = WebhookContext(source=SourceType.JIRA, channel_id="PROJ")
+        reg = CallbackRegistration(
+            conversation_id="admin-retry-1",
+            webhook_context=ctx,
+            status=CallbackStatus.ERROR,
+            attempts=1,
+            last_error="Timeout",
+        )
+        registry.register("admin-retry-1", reg)
+
+        handler = CallbackAdmin(MagicMock(), MagicMock())
+        request = MagicMock()
+        request.get_json.return_value = {
+            "action": "retry",
+            "conversation_id": "admin-retry-1",
+        }
+
+        with patch(
+            "python.api.callback_admin.CallbackRegistry.get_instance",
+            return_value=registry,
+        ):
+            result = await handler.process({}, request)
+
+        assert result["ok"] is True
+        updated = registry.get("admin-retry-1")
+        assert updated is not None
+        assert updated.status == CallbackStatus.PENDING

--- a/tests/test_external_identity.py
+++ b/tests/test_external_identity.py
@@ -1,0 +1,92 @@
+# tests/test_external_identity.py
+"""Tests for external identity linking (platform user <-> internal user)."""
+
+from unittest.mock import MagicMock
+
+
+class TestExternalIdentityModel:
+    def test_model_exists(self):
+        from python.helpers.user_store import ExternalIdentity
+
+        assert ExternalIdentity.__tablename__ == "external_identities"
+
+    def test_model_fields(self):
+        from python.helpers.user_store import ExternalIdentity
+
+        columns = {c.name for c in ExternalIdentity.__table__.columns}
+        assert "id" in columns
+        assert "user_id" in columns
+        assert "platform" in columns
+        assert "external_user_id" in columns
+        assert "external_display_name" in columns
+        assert "access_token_vault_id" in columns
+        assert "refresh_token_vault_id" in columns
+        assert "token_expires_at" in columns
+        assert "created_at" in columns
+        assert "last_used_at" in columns
+
+    def test_unique_constraint(self):
+        """Each (platform, external_user_id) pair must be unique."""
+        from python.helpers.user_store import ExternalIdentity
+
+        constraints = ExternalIdentity.__table__.constraints
+        unique_found = any(
+            hasattr(c, "columns")
+            and {col.name for col in c.columns} == {"platform", "external_user_id"}
+            for c in constraints
+        )
+        assert unique_found, "Missing unique constraint on (platform, external_user_id)"
+
+
+class TestExternalIdentityCRUD:
+    def _get_mock_session(self):
+        return MagicMock()
+
+    def test_link_external_identity(self):
+        from python.helpers.user_store import link_external_identity
+
+        db = self._get_mock_session()
+        db.query.return_value.filter.return_value.first.return_value = None
+
+        result = link_external_identity(
+            db,
+            user_id="user-1",
+            platform="slack",
+            external_user_id="U12345",
+            external_display_name="testuser",
+        )
+        db.add.assert_called_once()
+        assert result.user_id == "user-1"
+        assert result.platform == "slack"
+        assert result.external_user_id == "U12345"
+
+    def test_get_identity_by_external_id(self):
+        from python.helpers.user_store import get_identity_by_external_id
+
+        db = self._get_mock_session()
+        mock_identity = MagicMock()
+        mock_identity.user_id = "user-1"
+        db.query.return_value.filter.return_value.first.return_value = mock_identity
+
+        result = get_identity_by_external_id(db, "slack", "U12345")
+        assert result is not None
+        assert result.user_id == "user-1"
+
+    def test_get_identity_by_external_id_not_found(self):
+        from python.helpers.user_store import get_identity_by_external_id
+
+        db = self._get_mock_session()
+        db.query.return_value.filter.return_value.first.return_value = None
+
+        result = get_identity_by_external_id(db, "slack", "UNKNOWN")
+        assert result is None
+
+    def test_list_identities_for_user(self):
+        from python.helpers.user_store import list_identities_for_user
+
+        db = self._get_mock_session()
+        mock_ids = [MagicMock(), MagicMock()]
+        db.query.return_value.filter.return_value.all.return_value = mock_ids
+
+        result = list_identities_for_user(db, "user-1")
+        assert len(result) == 2

--- a/tests/test_github_callback_delivery.py
+++ b/tests/test_github_callback_delivery.py
@@ -1,0 +1,111 @@
+# tests/test_github_callback_delivery.py
+"""Tests for GitHub-specific callback delivery."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestGitHubDeliveryRouting:
+    @pytest.mark.asyncio
+    async def test_github_source_routes_to_github_delivery(self):
+        from python.extensions.monologue_end._80_integration_callback import (
+            IntegrationCallback,
+        )
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            CallbackStatus,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        ctx = WebhookContext(
+            source=SourceType.GITHUB,
+            channel_id="owner/repo",
+            metadata={
+                "issue_number": 42,
+                "event_type": "issues",
+            },
+        )
+        reg = CallbackRegistration(
+            conversation_id="ctx-gh-deliver", webhook_context=ctx
+        )
+        registry.register("ctx-gh-deliver", reg)
+
+        agent = MagicMock()
+        agent.number = 0
+        agent.context = MagicMock()
+        agent.context.id = "ctx-gh-deliver"
+        msg = MagicMock()
+        msg.role = "assistant"
+        msg.content = "I fixed the issue by updating the config."
+        agent.history = [msg]
+
+        ext = IntegrationCallback(agent)
+
+        with (
+            patch(
+                "python.extensions.monologue_end._80_integration_callback.CallbackRegistry.get_instance",
+                return_value=registry,
+            ),
+            patch(
+                "python.extensions.monologue_end._80_integration_callback.IntegrationCallback._deliver_github",
+                new_callable=AsyncMock,
+            ) as mock_gh,
+        ):
+            await ext.execute(loop_data=MagicMock())
+
+        mock_gh.assert_called_once()
+        assert reg.status == CallbackStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_github_delivery_receives_summary_and_reg(self):
+        from python.extensions.monologue_end._80_integration_callback import (
+            IntegrationCallback,
+        )
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        ctx = WebhookContext(
+            source=SourceType.GITHUB,
+            channel_id="owner/repo",
+            metadata={"issue_number": 10},
+        )
+        reg = CallbackRegistration(conversation_id="ctx-gh-args", webhook_context=ctx)
+        registry.register("ctx-gh-args", reg)
+
+        agent = MagicMock()
+        agent.number = 0
+        agent.context = MagicMock()
+        agent.context.id = "ctx-gh-args"
+        msg = MagicMock()
+        msg.role = "assistant"
+        msg.content = "Done with the task."
+        agent.history = [msg]
+
+        ext = IntegrationCallback(agent)
+
+        with (
+            patch(
+                "python.extensions.monologue_end._80_integration_callback.CallbackRegistry.get_instance",
+                return_value=registry,
+            ),
+            patch(
+                "python.extensions.monologue_end._80_integration_callback.IntegrationCallback._deliver_github",
+                new_callable=AsyncMock,
+            ) as mock_gh,
+        ):
+            await ext.execute(loop_data=MagicMock())
+
+        # Verify it received the registration and a summary string
+        args = mock_gh.call_args
+        assert args[0][0] is reg
+        assert isinstance(args[0][1], str)
+        assert "Done with the task" in args[0][1]

--- a/tests/test_integration_callback_extension.py
+++ b/tests/test_integration_callback_extension.py
@@ -1,0 +1,95 @@
+# tests/test_integration_callback_extension.py
+"""Tests for the integration callback monologue_end extension."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_agent_mock(context_id="ctx-test"):
+    """Create a minimal Agent mock for extension tests."""
+    agent = MagicMock()
+    agent.number = 0  # Main agent
+    agent.context = MagicMock()
+    agent.context.id = context_id
+    agent.context.user_id = "user-1"
+    agent.history = []
+    return agent
+
+
+def _make_loop_data():
+    """Create a minimal LoopData-like object."""
+    ld = MagicMock()
+    ld.iteration = 3
+    ld.user_message = "fix the bug"
+    return ld
+
+
+class TestCallbackExtensionSkips:
+    @pytest.mark.asyncio
+    async def test_skips_subordinate_agents(self):
+        from python.extensions.monologue_end._80_integration_callback import (
+            IntegrationCallback,
+        )
+
+        agent = _make_agent_mock()
+        agent.number = 1  # Subordinate, not main
+        ext = IntegrationCallback(agent)
+        # Should return without error (no callback check needed)
+        await ext.execute(loop_data=_make_loop_data())
+
+    @pytest.mark.asyncio
+    async def test_skips_when_no_callback_registered(self):
+        from python.extensions.monologue_end._80_integration_callback import (
+            IntegrationCallback,
+        )
+        from python.helpers.callback_registry import CallbackRegistry
+
+        agent = _make_agent_mock(context_id="no-callback")
+        registry = CallbackRegistry()
+        ext = IntegrationCallback(agent)
+
+        with patch(
+            "python.extensions.monologue_end._80_integration_callback.CallbackRegistry.get_instance",
+            return_value=registry,
+        ):
+            await ext.execute(loop_data=_make_loop_data())
+        # No error, no side effects
+
+
+class TestCallbackExtensionFires:
+    @pytest.mark.asyncio
+    async def test_fires_callback_for_registered_conversation(self):
+        from python.extensions.monologue_end._80_integration_callback import (
+            IntegrationCallback,
+        )
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            CallbackStatus,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        ctx = WebhookContext(source=SourceType.SLACK, channel_id="C1", thread_id="t1")
+        reg = CallbackRegistration(conversation_id="ctx-fire", webhook_context=ctx)
+        registry.register("ctx-fire", reg)
+
+        agent = _make_agent_mock(context_id="ctx-fire")
+        ext = IntegrationCallback(agent)
+
+        with (
+            patch(
+                "python.extensions.monologue_end._80_integration_callback.CallbackRegistry.get_instance",
+                return_value=registry,
+            ),
+            patch(
+                "python.extensions.monologue_end._80_integration_callback.IntegrationCallback._deliver_callback",
+                new_callable=AsyncMock,
+            ) as mock_deliver,
+        ):
+            await ext.execute(loop_data=_make_loop_data())
+
+        mock_deliver.assert_called_once()
+        assert reg.status == CallbackStatus.COMPLETED

--- a/tests/test_integration_models.py
+++ b/tests/test_integration_models.py
@@ -1,0 +1,131 @@
+# tests/test_integration_models.py
+"""Tests for integration message models."""
+
+from datetime import datetime
+
+
+class TestSourceType:
+    def test_slack_source(self):
+        from python.helpers.integration_models import SourceType
+
+        assert SourceType.SLACK == "slack"
+
+    def test_github_source(self):
+        from python.helpers.integration_models import SourceType
+
+        assert SourceType.GITHUB == "github"
+
+    def test_jira_source(self):
+        from python.helpers.integration_models import SourceType
+
+        assert SourceType.JIRA == "jira"
+
+    def test_internal_source(self):
+        from python.helpers.integration_models import SourceType
+
+        assert SourceType.INTERNAL == "internal"
+
+
+class TestIntegrationMessage:
+    def test_create_minimal(self):
+        from python.helpers.integration_models import IntegrationMessage, SourceType
+
+        msg = IntegrationMessage(
+            source=SourceType.SLACK,
+            text="Hello agent",
+            external_user_id="U12345",
+        )
+        assert msg.source == SourceType.SLACK
+        assert msg.text == "Hello agent"
+        assert msg.external_user_id == "U12345"
+        assert msg.external_message_id is None
+        assert isinstance(msg.received_at, datetime)
+
+    def test_create_full(self):
+        from python.helpers.integration_models import IntegrationMessage, SourceType
+
+        msg = IntegrationMessage(
+            source=SourceType.GITHUB,
+            text="Fix this bug",
+            external_user_id="user123",
+            external_user_name="octocat",
+            external_message_id="issue-42",
+            thread_id="PR-99",
+            channel_id="jrmatherly/apollos-ai",
+            metadata={"issue_number": 42, "action": "opened"},
+        )
+        assert msg.metadata["issue_number"] == 42
+        assert msg.channel_id == "jrmatherly/apollos-ai"
+
+    def test_message_serialization(self):
+        from python.helpers.integration_models import IntegrationMessage, SourceType
+
+        msg = IntegrationMessage(
+            source=SourceType.SLACK,
+            text="test",
+            external_user_id="U1",
+        )
+        data = msg.model_dump()
+        assert data["source"] == "slack"
+        assert "received_at" in data
+
+    def test_message_from_dict(self):
+        from python.helpers.integration_models import IntegrationMessage, SourceType
+
+        data = {
+            "source": "slack",
+            "text": "hello",
+            "external_user_id": "U1",
+        }
+        msg = IntegrationMessage.model_validate(data)
+        assert msg.source == SourceType.SLACK
+
+
+class TestWebhookContext:
+    def test_create(self):
+        from python.helpers.integration_models import WebhookContext, SourceType
+
+        ctx = WebhookContext(
+            source=SourceType.SLACK,
+            channel_id="C12345",
+            thread_id="1234567890.123456",
+            team_id="T12345",
+            response_url=None,
+        )
+        assert ctx.source == SourceType.SLACK
+        assert ctx.channel_id == "C12345"
+
+    def test_callback_key(self):
+        from python.helpers.integration_models import WebhookContext, SourceType
+
+        ctx = WebhookContext(
+            source=SourceType.GITHUB,
+            channel_id="jrmatherly/apollos-ai",
+            thread_id="issue-42",
+        )
+        key = ctx.callback_key()
+        assert "github" in key
+        assert "issue-42" in key
+
+
+class TestCallbackRegistration:
+    def test_create(self):
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            CallbackStatus,
+            SourceType,
+            WebhookContext,
+        )
+
+        ctx = WebhookContext(
+            source=SourceType.SLACK,
+            channel_id="C12345",
+            thread_id="t1",
+        )
+        reg = CallbackRegistration(
+            conversation_id="ctx-abc",
+            webhook_context=ctx,
+        )
+        assert reg.status == CallbackStatus.PENDING
+        assert reg.conversation_id == "ctx-abc"
+        assert reg.attempts == 0

--- a/tests/test_integration_settings.py
+++ b/tests/test_integration_settings.py
@@ -1,0 +1,62 @@
+# tests/test_integration_settings.py
+"""Tests for integration settings fields."""
+
+
+class TestIntegrationSettingsExist:
+    def test_slack_webhook_secret_field(self):
+        from python.helpers.settings import get_default_settings
+
+        settings = get_default_settings()
+        assert "slack_signing_secret" in settings
+        assert settings["slack_signing_secret"] == ""
+
+    def test_slack_bot_token_field(self):
+        from python.helpers.settings import get_default_settings
+
+        settings = get_default_settings()
+        assert "slack_bot_token" in settings
+        assert settings["slack_bot_token"] == ""
+
+    def test_github_webhook_secret_field(self):
+        from python.helpers.settings import get_default_settings
+
+        settings = get_default_settings()
+        assert "github_webhook_secret" in settings
+        assert settings["github_webhook_secret"] == ""
+
+    def test_github_app_id_field(self):
+        from python.helpers.settings import get_default_settings
+
+        settings = get_default_settings()
+        assert "github_app_id" in settings
+        assert settings["github_app_id"] == ""
+
+    def test_jira_webhook_secret_field(self):
+        from python.helpers.settings import get_default_settings
+
+        settings = get_default_settings()
+        assert "jira_webhook_secret" in settings
+        assert settings["jira_webhook_secret"] == ""
+
+    def test_jira_site_url_field(self):
+        from python.helpers.settings import get_default_settings
+
+        settings = get_default_settings()
+        assert "jira_site_url" in settings
+        assert settings["jira_site_url"] == ""
+
+    def test_integrations_enabled_field(self):
+        from python.helpers.settings import get_default_settings
+
+        settings = get_default_settings()
+        assert "integrations_enabled" in settings
+        assert settings["integrations_enabled"] is False
+
+
+class TestIntegrationSettingsEnvOverride:
+    def test_env_override_slack(self, monkeypatch):
+        monkeypatch.setenv("A0_SET_SLACK_SIGNING_SECRET", "xoxb-test")
+        from python.helpers.settings import get_default_value
+
+        val = get_default_value("slack_signing_secret", "")
+        assert val == "xoxb-test"

--- a/tests/test_integration_settings_api.py
+++ b/tests/test_integration_settings_api.py
@@ -1,0 +1,101 @@
+# tests/test_integration_settings_api.py
+"""Tests for the integration settings API endpoint."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestIntegrationSettingsApiImport:
+    def test_handler_importable(self):
+        from python.api.integration_settings_get import IntegrationSettingsGet
+
+        assert IntegrationSettingsGet is not None
+
+    def test_get_method_only(self):
+        from python.api.integration_settings_get import IntegrationSettingsGet
+
+        assert IntegrationSettingsGet.get_methods() == ["GET"]
+
+
+class TestIntegrationSettingsApiResponse:
+    @pytest.mark.asyncio
+    async def test_returns_integration_settings(self):
+        from python.api.integration_settings_get import IntegrationSettingsGet
+
+        handler = IntegrationSettingsGet(MagicMock(), MagicMock())
+        mock_settings = {
+            "integrations_enabled": True,
+            "slack_signing_secret": "xoxb-secret",
+            "slack_bot_token": "xoxb-token",
+            "github_webhook_secret": "gh-secret",
+            "github_app_id": "12345",
+            "jira_webhook_secret": "jira-secret",
+            "jira_site_url": "https://myorg.atlassian.net",
+        }
+
+        with patch(
+            "python.api.integration_settings_get.get_settings",
+            return_value=mock_settings,
+        ):
+            result = await handler.process({}, MagicMock())
+
+        assert result["integrations_enabled"] is True
+        assert result["has_slack_secret"] is True
+        assert result["has_slack_token"] is True
+        assert result["has_github_secret"] is True
+        assert result["github_app_id"] == "12345"
+        assert result["has_jira_secret"] is True
+        assert result["jira_site_url"] == "https://myorg.atlassian.net"
+
+    @pytest.mark.asyncio
+    async def test_masks_secrets(self):
+        """Secrets should not be returned in plaintext."""
+        from python.api.integration_settings_get import IntegrationSettingsGet
+
+        handler = IntegrationSettingsGet(MagicMock(), MagicMock())
+        mock_settings = {
+            "integrations_enabled": False,
+            "slack_signing_secret": "my-super-secret",
+            "slack_bot_token": "",
+            "github_webhook_secret": "",
+            "github_app_id": "",
+            "jira_webhook_secret": "",
+            "jira_site_url": "",
+        }
+
+        with patch(
+            "python.api.integration_settings_get.get_settings",
+            return_value=mock_settings,
+        ):
+            result = await handler.process({}, MagicMock())
+
+        # Should NOT contain the actual secret value
+        assert "my-super-secret" not in str(result)
+        # Should indicate whether a secret is set
+        assert result["has_slack_secret"] is True
+        assert result["has_slack_token"] is False
+
+    @pytest.mark.asyncio
+    async def test_empty_settings(self):
+        from python.api.integration_settings_get import IntegrationSettingsGet
+
+        handler = IntegrationSettingsGet(MagicMock(), MagicMock())
+        mock_settings = {
+            "integrations_enabled": False,
+            "slack_signing_secret": "",
+            "slack_bot_token": "",
+            "github_webhook_secret": "",
+            "github_app_id": "",
+            "jira_webhook_secret": "",
+            "jira_site_url": "",
+        }
+
+        with patch(
+            "python.api.integration_settings_get.get_settings",
+            return_value=mock_settings,
+        ):
+            result = await handler.process({}, MagicMock())
+
+        assert result["integrations_enabled"] is False
+        assert result["has_slack_secret"] is False

--- a/tests/test_jira_callback_delivery.py
+++ b/tests/test_jira_callback_delivery.py
@@ -1,0 +1,111 @@
+# tests/test_jira_callback_delivery.py
+"""Tests for Jira-specific callback delivery."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestJiraDeliveryRouting:
+    @pytest.mark.asyncio
+    async def test_jira_source_routes_to_jira_delivery(self):
+        from python.extensions.monologue_end._80_integration_callback import (
+            IntegrationCallback,
+        )
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            CallbackStatus,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        ctx = WebhookContext(
+            source=SourceType.JIRA,
+            channel_id="PROJ",
+            metadata={
+                "issue_key": "PROJ-42",
+                "event_type": "jira:issue_created",
+            },
+        )
+        reg = CallbackRegistration(
+            conversation_id="ctx-jira-deliver", webhook_context=ctx
+        )
+        registry.register("ctx-jira-deliver", reg)
+
+        agent = MagicMock()
+        agent.number = 0
+        agent.context = MagicMock()
+        agent.context.id = "ctx-jira-deliver"
+        msg = MagicMock()
+        msg.role = "assistant"
+        msg.content = "I analyzed the Jira issue and found the root cause."
+        agent.history = [msg]
+
+        ext = IntegrationCallback(agent)
+
+        with (
+            patch(
+                "python.extensions.monologue_end._80_integration_callback.CallbackRegistry.get_instance",
+                return_value=registry,
+            ),
+            patch(
+                "python.extensions.monologue_end._80_integration_callback.IntegrationCallback._deliver_jira",
+                new_callable=AsyncMock,
+            ) as mock_jira,
+        ):
+            await ext.execute(loop_data=MagicMock())
+
+        mock_jira.assert_called_once()
+        assert reg.status == CallbackStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_jira_delivery_receives_summary_and_reg(self):
+        from python.extensions.monologue_end._80_integration_callback import (
+            IntegrationCallback,
+        )
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        ctx = WebhookContext(
+            source=SourceType.JIRA,
+            channel_id="PROJ",
+            metadata={"issue_key": "PROJ-10"},
+        )
+        reg = CallbackRegistration(conversation_id="ctx-jira-args", webhook_context=ctx)
+        registry.register("ctx-jira-args", reg)
+
+        agent = MagicMock()
+        agent.number = 0
+        agent.context = MagicMock()
+        agent.context.id = "ctx-jira-args"
+        msg = MagicMock()
+        msg.role = "assistant"
+        msg.content = "Completed the Jira task."
+        agent.history = [msg]
+
+        ext = IntegrationCallback(agent)
+
+        with (
+            patch(
+                "python.extensions.monologue_end._80_integration_callback.CallbackRegistry.get_instance",
+                return_value=registry,
+            ),
+            patch(
+                "python.extensions.monologue_end._80_integration_callback.IntegrationCallback._deliver_jira",
+                new_callable=AsyncMock,
+            ) as mock_jira,
+        ):
+            await ext.execute(loop_data=MagicMock())
+
+        # Verify it received the registration and a summary string
+        args = mock_jira.call_args
+        assert args[0][0] is reg
+        assert isinstance(args[0][1], str)
+        assert "Completed the Jira task" in args[0][1]

--- a/tests/test_jira_markup.py
+++ b/tests/test_jira_markup.py
@@ -1,0 +1,163 @@
+# tests/test_jira_markup.py
+"""Tests for Markdown-to-Jira wiki markup converter."""
+
+
+class TestJiraMarkupImport:
+    def test_module_importable(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        assert callable(markdown_to_jira)
+
+
+class TestJiraMarkupHeaders:
+    def test_h1(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        assert markdown_to_jira("# Heading 1") == "h1. Heading 1"
+
+    def test_h2(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        assert markdown_to_jira("## Heading 2") == "h2. Heading 2"
+
+    def test_h3(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        assert markdown_to_jira("### Heading 3") == "h3. Heading 3"
+
+    def test_h6(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        assert markdown_to_jira("###### Heading 6") == "h6. Heading 6"
+
+
+class TestJiraMarkupInlineFormatting:
+    def test_bold(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        assert markdown_to_jira("**bold text**") == "*bold text*"
+
+    def test_italic(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        assert markdown_to_jira("*italic text*") == "_italic text_"
+
+    def test_inline_code(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        assert markdown_to_jira("`some code`") == "{{some code}}"
+
+    def test_strikethrough(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        assert markdown_to_jira("~~deleted~~") == "-deleted-"
+
+
+class TestJiraMarkupLinks:
+    def test_link(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        result = markdown_to_jira("[Click here](https://example.com)")
+        assert result == "[Click here|https://example.com]"
+
+    def test_link_in_text(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        result = markdown_to_jira("See [docs](https://docs.example.com) for info")
+        assert "[docs|https://docs.example.com]" in result
+
+
+class TestJiraMarkupCodeBlocks:
+    def test_fenced_code_block(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        md = "```\nprint('hello')\n```"
+        result = markdown_to_jira(md)
+        assert "{code}" in result
+        assert "print('hello')" in result
+
+    def test_fenced_code_block_with_language(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        md = "```python\ndef foo():\n    pass\n```"
+        result = markdown_to_jira(md)
+        assert "{code:python}" in result
+        assert "def foo():" in result
+
+
+class TestJiraMarkupLists:
+    def test_unordered_list(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        md = "- item 1\n- item 2\n- item 3"
+        result = markdown_to_jira(md)
+        assert "* item 1" in result
+        assert "* item 2" in result
+
+    def test_ordered_list(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        md = "1. first\n2. second\n3. third"
+        result = markdown_to_jira(md)
+        assert "# first" in result
+        assert "# second" in result
+
+
+class TestJiraMarkupBlockquotes:
+    def test_blockquote(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        result = markdown_to_jira("> This is a quote")
+        assert "{quote}" in result
+        assert "This is a quote" in result
+
+
+class TestJiraMarkupHorizontalRule:
+    def test_horizontal_rule(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        result = markdown_to_jira("---")
+        assert "----" in result
+
+
+class TestJiraMarkupMultiline:
+    def test_mixed_content(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        md = """# Summary
+
+The issue is caused by **incorrect configuration**.
+
+## Steps
+
+1. Check the `config.yaml` file
+2. Update the setting
+3. Restart the service
+
+```python
+config = load_config()
+```
+
+> Note: This is important.
+
+See [the docs](https://example.com) for details."""
+
+        result = markdown_to_jira(md)
+        assert "h1. Summary" in result
+        assert "*incorrect configuration*" in result
+        assert "h2. Steps" in result
+        assert "# Check the" in result
+        assert "{{config.yaml}}" in result
+        assert "{code:python}" in result
+        assert "{quote}" in result
+        assert "[the docs|https://example.com]" in result
+
+    def test_empty_input(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        assert markdown_to_jira("") == ""
+
+    def test_plain_text_unchanged(self):
+        from python.helpers.jira_markup import markdown_to_jira
+
+        assert markdown_to_jira("Just plain text") == "Just plain text"

--- a/tests/test_plan_approval.py
+++ b/tests/test_plan_approval.py
@@ -1,0 +1,152 @@
+# tests/test_plan_approval.py
+"""Tests for human-in-the-loop plan approval workflow."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestAwaitingApprovalStatus:
+    def test_awaiting_approval_status_exists(self):
+        from python.helpers.integration_models import CallbackStatus
+
+        assert hasattr(CallbackStatus, "AWAITING_APPROVAL")
+        assert CallbackStatus.AWAITING_APPROVAL == "awaiting_approval"
+
+
+class TestCallbackRegistryApprovalMethods:
+    def test_list_awaiting_approval(self):
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            CallbackStatus,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        ctx = WebhookContext(source=SourceType.GITHUB, channel_id="owner/repo")
+        reg = CallbackRegistration(
+            conversation_id="approval-test-1",
+            webhook_context=ctx,
+            status=CallbackStatus.AWAITING_APPROVAL,
+        )
+        registry.register("approval-test-1", reg)
+
+        # Add a non-approval callback
+        reg2 = CallbackRegistration(
+            conversation_id="approval-test-2",
+            webhook_context=ctx,
+            status=CallbackStatus.PENDING,
+        )
+        registry.register("approval-test-2", reg2)
+
+        awaiting = registry.list_awaiting_approval()
+        assert len(awaiting) == 1
+        assert awaiting[0].conversation_id == "approval-test-1"
+
+    def test_list_all_returns_all_registrations(self):
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            CallbackStatus,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        ctx = WebhookContext(source=SourceType.SLACK, channel_id="C123")
+        for i in range(3):
+            reg = CallbackRegistration(
+                conversation_id=f"list-all-{i}",
+                webhook_context=ctx,
+                status=CallbackStatus.PENDING,
+            )
+            registry.register(f"list-all-{i}", reg)
+
+        all_regs = registry.list_all()
+        assert len(all_regs) == 3
+
+
+class TestApprovalWebhookHandling:
+    @pytest.mark.asyncio
+    async def test_approval_comment_transitions_to_pending(self):
+        """When an approval comment arrives, status should go from
+        AWAITING_APPROVAL to PENDING so the callback extension picks it up."""
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            CallbackStatus,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        ctx = WebhookContext(
+            source=SourceType.GITHUB,
+            channel_id="owner/repo",
+            metadata={"issue_number": 42, "event_type": "issues"},
+        )
+        reg = CallbackRegistration(
+            conversation_id="github:owner/repo:issue:42",
+            webhook_context=ctx,
+            status=CallbackStatus.AWAITING_APPROVAL,
+        )
+        registry.register("github:owner/repo:issue:42", reg)
+
+        # Simulate approval
+        registry.update_status("github:owner/repo:issue:42", CallbackStatus.PENDING)
+
+        updated = registry.get("github:owner/repo:issue:42")
+        assert updated is not None
+        assert updated.status == CallbackStatus.PENDING
+
+    @pytest.mark.asyncio
+    async def test_callback_extension_skips_awaiting_approval(self):
+        """The callback extension should not fire for AWAITING_APPROVAL status."""
+        from python.extensions.monologue_end._80_integration_callback import (
+            IntegrationCallback,
+        )
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            CallbackStatus,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        ctx = WebhookContext(
+            source=SourceType.SLACK,
+            channel_id="C123",
+        )
+        reg = CallbackRegistration(
+            conversation_id="ctx-skip-approval",
+            webhook_context=ctx,
+            status=CallbackStatus.AWAITING_APPROVAL,
+        )
+        registry.register("ctx-skip-approval", reg)
+
+        agent = MagicMock()
+        agent.number = 0
+        agent.context = MagicMock()
+        agent.context.id = "ctx-skip-approval"
+
+        ext = IntegrationCallback(agent)
+
+        with (
+            patch(
+                "python.extensions.monologue_end._80_integration_callback.CallbackRegistry.get_instance",
+                return_value=registry,
+            ),
+            patch(
+                "python.extensions.monologue_end._80_integration_callback.IntegrationCallback._deliver_callback",
+                new_callable=AsyncMock,
+            ) as mock_deliver,
+        ):
+            await ext.execute(loop_data=MagicMock())
+
+        # Should NOT have called _deliver_callback because status is AWAITING_APPROVAL
+        mock_deliver.assert_not_called()
+        # Status should remain unchanged
+        assert reg.status == CallbackStatus.AWAITING_APPROVAL

--- a/tests/test_slack_callback_delivery.py
+++ b/tests/test_slack_callback_delivery.py
@@ -1,0 +1,133 @@
+# tests/test_slack_callback_delivery.py
+"""Tests for Slack-specific callback delivery via MCP outbound."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_agent_mock(context_id="ctx-slack"):
+    agent = MagicMock()
+    agent.number = 0
+    agent.context = MagicMock()
+    agent.context.id = context_id
+    agent.history = []
+    # Mock the MCP call method
+    agent.call_utility_llm = AsyncMock()
+    return agent
+
+
+class TestSlackDeliveryRouting:
+    @pytest.mark.asyncio
+    async def test_slack_source_routes_to_slack_delivery(self):
+        from python.extensions.monologue_end._80_integration_callback import (
+            IntegrationCallback,
+        )
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            CallbackStatus,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        ctx = WebhookContext(
+            source=SourceType.SLACK,
+            channel_id="C1234",
+            thread_id="1234567890.000000",
+            metadata={"bot_token_available": True},
+        )
+        reg = CallbackRegistration(
+            conversation_id="ctx-slack-deliver", webhook_context=ctx
+        )
+        registry.register("ctx-slack-deliver", reg)
+
+        agent = _make_agent_mock(context_id="ctx-slack-deliver")
+        # Add a response to history
+        msg = MagicMock()
+        msg.role = "assistant"
+        msg.content = "I fixed the bug by updating the config."
+        agent.history = [msg]
+
+        ext = IntegrationCallback(agent)
+
+        with (
+            patch(
+                "python.extensions.monologue_end._80_integration_callback.CallbackRegistry.get_instance",
+                return_value=registry,
+            ),
+            patch(
+                "python.extensions.monologue_end._80_integration_callback.IntegrationCallback._deliver_slack",
+                new_callable=AsyncMock,
+            ) as mock_slack,
+        ):
+            await ext.execute(loop_data=MagicMock())
+
+        mock_slack.assert_called_once()
+        assert reg.status == CallbackStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_non_slack_source_does_not_call_slack_delivery(self):
+        from python.extensions.monologue_end._80_integration_callback import (
+            IntegrationCallback,
+        )
+        from python.helpers.callback_registry import CallbackRegistry
+        from python.helpers.integration_models import (
+            CallbackRegistration,
+            SourceType,
+            WebhookContext,
+        )
+
+        registry = CallbackRegistry()
+        ctx = WebhookContext(source=SourceType.GITHUB, channel_id="repo/issue/1")
+        reg = CallbackRegistration(
+            conversation_id="ctx-github-no-slack", webhook_context=ctx
+        )
+        registry.register("ctx-github-no-slack", reg)
+
+        agent = _make_agent_mock(context_id="ctx-github-no-slack")
+        ext = IntegrationCallback(agent)
+
+        with (
+            patch(
+                "python.extensions.monologue_end._80_integration_callback.CallbackRegistry.get_instance",
+                return_value=registry,
+            ),
+            patch(
+                "python.extensions.monologue_end._80_integration_callback.IntegrationCallback._deliver_slack",
+                new_callable=AsyncMock,
+            ) as mock_slack,
+        ):
+            await ext.execute(loop_data=MagicMock())
+
+        mock_slack.assert_not_called()
+
+
+class TestSlackDeliveryContent:
+    @pytest.mark.asyncio
+    async def test_extracts_summary_from_history(self):
+        from python.extensions.monologue_end._80_integration_callback import (
+            IntegrationCallback,
+        )
+
+        agent = _make_agent_mock()
+        msg = MagicMock()
+        msg.role = "assistant"
+        msg.content = "Here is the answer to your question."
+        agent.history = [msg]
+
+        ext = IntegrationCallback(agent)
+        summary = ext._extract_summary(MagicMock())
+        assert "Here is the answer" in summary
+
+    def test_extract_summary_fallback(self):
+        from python.extensions.monologue_end._80_integration_callback import (
+            IntegrationCallback,
+        )
+
+        agent = _make_agent_mock()
+        agent.history = []
+        ext = IntegrationCallback(agent)
+        summary = ext._extract_summary(MagicMock())
+        assert summary == "Agent completed the task."

--- a/tests/test_slack_identity.py
+++ b/tests/test_slack_identity.py
@@ -1,0 +1,85 @@
+# tests/test_slack_identity.py
+"""Tests for Slack OAuth identity linking."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestSlackOAuthImport:
+    def test_handler_importable(self):
+        from python.api.webhook_slack_oauth import WebhookSlackOauth
+
+        assert WebhookSlackOauth is not None
+
+    def test_requires_no_csrf(self):
+        from python.api.webhook_slack_oauth import WebhookSlackOauth
+
+        assert WebhookSlackOauth.requires_csrf() is False
+
+    def test_get_method(self):
+        from python.api.webhook_slack_oauth import WebhookSlackOauth
+
+        assert "GET" in WebhookSlackOauth.get_methods()
+
+
+class TestSlackOAuthCallback:
+    @pytest.mark.asyncio
+    async def test_missing_code_returns_error(self):
+        from python.api.webhook_slack_oauth import WebhookSlackOauth
+
+        handler = WebhookSlackOauth(MagicMock(), MagicMock())
+        request = MagicMock()
+        request.args = {}
+
+        result = await handler.process({}, request)
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_oauth_links_identity(self):
+        from python.api.webhook_slack_oauth import WebhookSlackOauth
+
+        handler = WebhookSlackOauth(MagicMock(), MagicMock())
+        request = MagicMock()
+        request.args = {"code": "test-oauth-code"}
+
+        mock_oauth_response = {
+            "ok": True,
+            "authed_user": {"id": "U_SLACK_123"},
+            "team": {"id": "T_TEAM_1", "name": "Test Team"},
+            "access_token": "xoxb-test-token",
+        }
+
+        with (
+            patch(
+                "python.api.webhook_slack_oauth._exchange_slack_code",
+                return_value=mock_oauth_response,
+            ),
+            patch(
+                "python.api.webhook_slack_oauth._link_slack_user",
+            ) as mock_link,
+            patch(
+                "python.api.webhook_slack_oauth.session",
+                {"user": {"id": "internal-user-1"}},
+            ),
+        ):
+            result = await handler.process({}, request)
+
+        mock_link.assert_called_once()
+        assert result.get("ok") is True
+
+    @pytest.mark.asyncio
+    async def test_oauth_error_from_slack(self):
+        from python.api.webhook_slack_oauth import WebhookSlackOauth
+
+        handler = WebhookSlackOauth(MagicMock(), MagicMock())
+        request = MagicMock()
+        request.args = {"code": "bad-code"}
+
+        with patch(
+            "python.api.webhook_slack_oauth._exchange_slack_code",
+            return_value={"ok": False, "error": "invalid_code"},
+        ):
+            result = await handler.process({}, request)
+
+        assert "error" in result

--- a/tests/test_webhook_event_log.py
+++ b/tests/test_webhook_event_log.py
@@ -1,0 +1,111 @@
+# tests/test_webhook_event_log.py
+"""Tests for webhook event logging."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestWebhookEventLogImport:
+    def test_module_importable(self):
+        from python.helpers.webhook_event_log import WebhookEventLog
+
+        assert WebhookEventLog is not None
+
+
+class TestWebhookEventLogStorage:
+    def test_log_event(self):
+        from python.helpers.webhook_event_log import WebhookEventLog
+
+        log = WebhookEventLog()
+        log.record(
+            source="github",
+            event_type="issues",
+            action="opened",
+            delivery_id="delivery-123",
+            payload_summary={"repo": "owner/repo", "number": 42},
+        )
+
+        events = log.recent(limit=10)
+        assert len(events) == 1
+        assert events[0]["source"] == "github"
+        assert events[0]["event_type"] == "issues"
+        assert events[0]["delivery_id"] == "delivery-123"
+
+    def test_recent_returns_newest_first(self):
+        from python.helpers.webhook_event_log import WebhookEventLog
+
+        log = WebhookEventLog()
+        for i in range(5):
+            log.record(
+                source="slack",
+                event_type="event_callback",
+                action="app_mention",
+                delivery_id=f"delivery-{i}",
+            )
+
+        events = log.recent(limit=3)
+        assert len(events) == 3
+        # Most recent should be first
+        assert events[0]["delivery_id"] == "delivery-4"
+
+    def test_max_entries_enforced(self):
+        from python.helpers.webhook_event_log import WebhookEventLog
+
+        log = WebhookEventLog(max_entries=5)
+        for i in range(10):
+            log.record(
+                source="jira",
+                event_type="jira:issue_created",
+                action="created",
+                delivery_id=f"d-{i}",
+            )
+
+        events = log.recent(limit=100)
+        assert len(events) == 5
+
+    def test_filter_by_source(self):
+        from python.helpers.webhook_event_log import WebhookEventLog
+
+        log = WebhookEventLog()
+        log.record(source="github", event_type="issues", action="opened")
+        log.record(source="slack", event_type="event_callback", action="app_mention")
+        log.record(source="github", event_type="pull_request", action="opened")
+
+        github_events = log.recent(limit=10, source="github")
+        assert len(github_events) == 2
+        assert all(e["source"] == "github" for e in github_events)
+
+
+class TestWebhookEventLogApi:
+    def test_handler_importable(self):
+        from python.api.webhook_events_get import WebhookEventsGet
+
+        assert WebhookEventsGet is not None
+
+    @pytest.mark.asyncio
+    async def test_returns_recent_events(self):
+        from python.api.webhook_events_get import WebhookEventsGet
+        from python.helpers.webhook_event_log import WebhookEventLog
+
+        log = WebhookEventLog()
+        log.record(
+            source="github",
+            event_type="issues",
+            action="opened",
+            delivery_id="test-delivery",
+        )
+
+        handler = WebhookEventsGet(MagicMock(), MagicMock())
+        request = MagicMock()
+        request.args = {}
+
+        with patch(
+            "python.api.webhook_events_get.WebhookEventLog.get_instance",
+            return_value=log,
+        ):
+            result = await handler.process({}, request)
+
+        assert "events" in result
+        assert len(result["events"]) == 1
+        assert result["events"][0]["source"] == "github"

--- a/tests/test_webhook_github.py
+++ b/tests/test_webhook_github.py
@@ -1,0 +1,269 @@
+# tests/test_webhook_github.py
+"""Tests for the GitHub webhook receiver API handler."""
+
+import hashlib
+import hmac
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_github_signature(body: bytes, secret: str) -> str:
+    """Generate a valid GitHub HMAC-SHA256 signature."""
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _make_request(
+    data: dict,
+    secret: str = "test-webhook-secret",
+    event_type: str = "issues",
+) -> MagicMock:
+    """Create a mock Flask Request with GitHub headers."""
+    body = json.dumps(data).encode()
+    sig = _make_github_signature(body, secret)
+    request = MagicMock()
+    request.data = body
+    request.get_json.return_value = data
+    request.headers = {
+        "X-Hub-Signature-256": sig,
+        "X-GitHub-Event": event_type,
+        "X-GitHub-Delivery": "delivery-123",
+    }
+    return request
+
+
+class TestGitHubWebhookImport:
+    def test_handler_importable(self):
+        from python.api.webhook_github import WebhookGithub
+
+        assert WebhookGithub is not None
+
+    def test_requires_no_auth(self):
+        from python.api.webhook_github import WebhookGithub
+
+        assert WebhookGithub.requires_auth() is False
+
+    def test_requires_no_csrf(self):
+        from python.api.webhook_github import WebhookGithub
+
+        assert WebhookGithub.requires_csrf() is False
+
+    def test_post_only(self):
+        from python.api.webhook_github import WebhookGithub
+
+        assert WebhookGithub.get_methods() == ["POST"]
+
+
+class TestGitHubSignatureRejection:
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_signature(self):
+        from python.api.webhook_github import WebhookGithub
+
+        handler = WebhookGithub(MagicMock(), MagicMock())
+        data = {"action": "opened", "issue": {"number": 1}}
+        request = _make_request(data, secret="wrong-secret")
+
+        with patch(
+            "python.api.webhook_github._get_github_webhook_secret",
+            return_value="correct-secret",
+        ):
+            result = await handler.process({}, request)
+
+        assert hasattr(result, "status_code")
+        assert result.status_code == 403
+
+
+class TestGitHubIssueEvents:
+    @pytest.mark.asyncio
+    async def test_issue_opened_triggers_processing(self):
+        from python.api.webhook_github import WebhookGithub
+
+        handler = WebhookGithub(MagicMock(), MagicMock())
+        data = {
+            "action": "opened",
+            "issue": {
+                "number": 42,
+                "title": "Bug report",
+                "body": "Something is broken",
+                "user": {"login": "testuser", "id": 12345},
+                "labels": [],
+            },
+            "repository": {
+                "full_name": "owner/repo",
+            },
+        }
+        request = _make_request(data, event_type="issues")
+
+        with (
+            patch(
+                "python.api.webhook_github._get_github_webhook_secret",
+                return_value="test-webhook-secret",
+            ),
+            patch(
+                "python.api.webhook_github.WebhookGithub._process_github_event",
+                new_callable=AsyncMock,
+            ) as mock_process,
+        ):
+            result = await handler.process({}, request)
+
+        assert result == {"ok": True}
+        mock_process.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_issue_labeled_triggers_processing(self):
+        from python.api.webhook_github import WebhookGithub
+
+        handler = WebhookGithub(MagicMock(), MagicMock())
+        data = {
+            "action": "labeled",
+            "label": {"name": "apollos-ai"},
+            "issue": {
+                "number": 10,
+                "title": "Feature request",
+                "body": "Add dark mode",
+                "user": {"login": "testuser", "id": 12345},
+                "labels": [{"name": "apollos-ai"}],
+            },
+            "repository": {"full_name": "owner/repo"},
+        }
+        request = _make_request(data, event_type="issues")
+
+        with (
+            patch(
+                "python.api.webhook_github._get_github_webhook_secret",
+                return_value="test-webhook-secret",
+            ),
+            patch(
+                "python.api.webhook_github.WebhookGithub._process_github_event",
+                new_callable=AsyncMock,
+            ) as mock_process,
+        ):
+            result = await handler.process({}, request)
+
+        assert result == {"ok": True}
+        mock_process.assert_called_once()
+
+
+class TestGitHubIssueCommentEvents:
+    @pytest.mark.asyncio
+    async def test_issue_comment_with_mention_triggers(self):
+        from python.api.webhook_github import WebhookGithub
+
+        handler = WebhookGithub(MagicMock(), MagicMock())
+        data = {
+            "action": "created",
+            "comment": {
+                "body": "@apollos-ai please fix this",
+                "user": {"login": "commenter", "id": 99},
+            },
+            "issue": {
+                "number": 5,
+                "title": "Test issue",
+                "body": "body text",
+                "user": {"login": "author", "id": 1},
+                "labels": [],
+            },
+            "repository": {"full_name": "owner/repo"},
+        }
+        request = _make_request(data, event_type="issue_comment")
+
+        with (
+            patch(
+                "python.api.webhook_github._get_github_webhook_secret",
+                return_value="test-webhook-secret",
+            ),
+            patch(
+                "python.api.webhook_github.WebhookGithub._process_github_event",
+                new_callable=AsyncMock,
+            ) as mock_process,
+        ):
+            result = await handler.process({}, request)
+
+        assert result == {"ok": True}
+        mock_process.assert_called_once()
+
+
+class TestGitHubPREvents:
+    @pytest.mark.asyncio
+    async def test_pr_opened_triggers_processing(self):
+        from python.api.webhook_github import WebhookGithub
+
+        handler = WebhookGithub(MagicMock(), MagicMock())
+        data = {
+            "action": "opened",
+            "pull_request": {
+                "number": 7,
+                "title": "Add feature",
+                "body": "This PR adds a feature",
+                "user": {"login": "dev", "id": 55},
+            },
+            "repository": {"full_name": "owner/repo"},
+        }
+        request = _make_request(data, event_type="pull_request")
+
+        with (
+            patch(
+                "python.api.webhook_github._get_github_webhook_secret",
+                return_value="test-webhook-secret",
+            ),
+            patch(
+                "python.api.webhook_github.WebhookGithub._process_github_event",
+                new_callable=AsyncMock,
+            ) as mock_process,
+        ):
+            result = await handler.process({}, request)
+
+        assert result == {"ok": True}
+        mock_process.assert_called_once()
+
+
+class TestGitHubIgnoredEvents:
+    @pytest.mark.asyncio
+    async def test_unhandled_event_type_returns_ok(self):
+        from python.api.webhook_github import WebhookGithub
+
+        handler = WebhookGithub(MagicMock(), MagicMock())
+        data = {"action": "deleted", "repository": {"full_name": "owner/repo"}}
+        request = _make_request(data, event_type="repository")
+
+        with patch(
+            "python.api.webhook_github._get_github_webhook_secret",
+            return_value="test-webhook-secret",
+        ):
+            result = await handler.process({}, request)
+
+        assert result == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_issue_closed_action_ignored(self):
+        from python.api.webhook_github import WebhookGithub
+
+        handler = WebhookGithub(MagicMock(), MagicMock())
+        data = {
+            "action": "closed",
+            "issue": {
+                "number": 1,
+                "title": "Old issue",
+                "body": "",
+                "user": {"login": "u", "id": 1},
+                "labels": [],
+            },
+            "repository": {"full_name": "owner/repo"},
+        }
+        request = _make_request(data, event_type="issues")
+
+        with (
+            patch(
+                "python.api.webhook_github._get_github_webhook_secret",
+                return_value="test-webhook-secret",
+            ),
+            patch(
+                "python.api.webhook_github.WebhookGithub._process_github_event",
+                new_callable=AsyncMock,
+            ) as mock_process,
+        ):
+            result = await handler.process({}, request)
+
+        assert result == {"ok": True}
+        mock_process.assert_not_called()

--- a/tests/test_webhook_jira.py
+++ b/tests/test_webhook_jira.py
@@ -1,0 +1,272 @@
+# tests/test_webhook_jira.py
+"""Tests for the Jira Cloud webhook receiver API handler."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_request(
+    data: dict,
+    secret: str = "test-jira-secret",
+    event_type: str = "jira:issue_created",
+) -> MagicMock:
+    """Create a mock Flask Request with Jira webhook headers."""
+    body = json.dumps(data).encode()
+    request = MagicMock()
+    request.data = body
+    request.get_json.return_value = data
+    request.headers = {
+        "X-Atlassian-Webhook-Identifier": "hook-123",
+    }
+    request.args = {"secret": secret}
+    return request
+
+
+class TestJiraWebhookImport:
+    def test_handler_importable(self):
+        from python.api.webhook_jira import WebhookJira
+
+        assert WebhookJira is not None
+
+    def test_requires_no_auth(self):
+        from python.api.webhook_jira import WebhookJira
+
+        assert WebhookJira.requires_auth() is False
+
+    def test_requires_no_csrf(self):
+        from python.api.webhook_jira import WebhookJira
+
+        assert WebhookJira.requires_csrf() is False
+
+    def test_post_only(self):
+        from python.api.webhook_jira import WebhookJira
+
+        assert WebhookJira.get_methods() == ["POST"]
+
+
+class TestJiraSignatureRejection:
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_secret(self):
+        from python.api.webhook_jira import WebhookJira
+
+        handler = WebhookJira(MagicMock(), MagicMock())
+        data = {
+            "webhookEvent": "jira:issue_created",
+            "issue": {"key": "PROJ-1", "fields": {"summary": "Test"}},
+        }
+        request = _make_request(data, secret="wrong-secret")
+
+        with patch(
+            "python.api.webhook_jira._get_jira_webhook_secret",
+            return_value="correct-secret",
+        ):
+            result = await handler.process({}, request)
+
+        assert hasattr(result, "status_code")
+        assert result.status_code == 403
+
+
+class TestJiraIssueEvents:
+    @pytest.mark.asyncio
+    async def test_issue_created_triggers_processing(self):
+        from python.api.webhook_jira import WebhookJira
+
+        handler = WebhookJira(MagicMock(), MagicMock())
+        data = {
+            "webhookEvent": "jira:issue_created",
+            "issue": {
+                "key": "PROJ-42",
+                "fields": {
+                    "summary": "Bug in production",
+                    "description": "Something is broken",
+                    "priority": {"name": "High"},
+                    "status": {"name": "Open"},
+                    "issuetype": {"name": "Bug"},
+                    "labels": [],
+                    "reporter": {
+                        "accountId": "abc123",
+                        "displayName": "Test User",
+                    },
+                },
+            },
+        }
+        request = _make_request(data)
+
+        with (
+            patch(
+                "python.api.webhook_jira._get_jira_webhook_secret",
+                return_value="test-jira-secret",
+            ),
+            patch(
+                "python.api.webhook_jira.WebhookJira._process_jira_event",
+                new_callable=AsyncMock,
+            ) as mock_process,
+        ):
+            result = await handler.process({}, request)
+
+        assert result == {"ok": True}
+        mock_process.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_issue_updated_with_label_triggers_processing(self):
+        from python.api.webhook_jira import WebhookJira
+
+        handler = WebhookJira(MagicMock(), MagicMock())
+        data = {
+            "webhookEvent": "jira:issue_updated",
+            "issue": {
+                "key": "PROJ-10",
+                "fields": {
+                    "summary": "Feature request",
+                    "description": "Add dark mode",
+                    "priority": {"name": "Medium"},
+                    "status": {"name": "To Do"},
+                    "issuetype": {"name": "Story"},
+                    "labels": ["apollos-ai"],
+                    "reporter": {
+                        "accountId": "def456",
+                        "displayName": "Another User",
+                    },
+                },
+            },
+            "changelog": {
+                "items": [
+                    {
+                        "field": "labels",
+                        "fromString": "",
+                        "toString": "apollos-ai",
+                    }
+                ]
+            },
+        }
+        request = _make_request(data)
+
+        with (
+            patch(
+                "python.api.webhook_jira._get_jira_webhook_secret",
+                return_value="test-jira-secret",
+            ),
+            patch(
+                "python.api.webhook_jira.WebhookJira._process_jira_event",
+                new_callable=AsyncMock,
+            ) as mock_process,
+        ):
+            result = await handler.process({}, request)
+
+        assert result == {"ok": True}
+        mock_process.assert_called_once()
+
+
+class TestJiraCommentEvents:
+    @pytest.mark.asyncio
+    async def test_comment_created_triggers_processing(self):
+        from python.api.webhook_jira import WebhookJira
+
+        handler = WebhookJira(MagicMock(), MagicMock())
+        data = {
+            "webhookEvent": "comment_created",
+            "comment": {
+                "body": "@apollos-ai please investigate",
+                "author": {
+                    "accountId": "user-789",
+                    "displayName": "Commenter",
+                },
+            },
+            "issue": {
+                "key": "PROJ-5",
+                "fields": {
+                    "summary": "Test issue",
+                    "description": "body text",
+                    "priority": {"name": "Low"},
+                    "status": {"name": "Open"},
+                    "issuetype": {"name": "Task"},
+                    "labels": [],
+                    "reporter": {
+                        "accountId": "abc",
+                        "displayName": "Reporter",
+                    },
+                },
+            },
+        }
+        request = _make_request(data)
+
+        with (
+            patch(
+                "python.api.webhook_jira._get_jira_webhook_secret",
+                return_value="test-jira-secret",
+            ),
+            patch(
+                "python.api.webhook_jira.WebhookJira._process_jira_event",
+                new_callable=AsyncMock,
+            ) as mock_process,
+        ):
+            result = await handler.process({}, request)
+
+        assert result == {"ok": True}
+        mock_process.assert_called_once()
+
+
+class TestJiraIgnoredEvents:
+    @pytest.mark.asyncio
+    async def test_unhandled_event_type_returns_ok(self):
+        from python.api.webhook_jira import WebhookJira
+
+        handler = WebhookJira(MagicMock(), MagicMock())
+        data = {"webhookEvent": "jira:issue_deleted", "issue": {"key": "X-1"}}
+        request = _make_request(data)
+
+        with patch(
+            "python.api.webhook_jira._get_jira_webhook_secret",
+            return_value="test-jira-secret",
+        ):
+            result = await handler.process({}, request)
+
+        assert result == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_issue_updated_without_label_change_ignored(self):
+        from python.api.webhook_jira import WebhookJira
+
+        handler = WebhookJira(MagicMock(), MagicMock())
+        data = {
+            "webhookEvent": "jira:issue_updated",
+            "issue": {
+                "key": "PROJ-99",
+                "fields": {
+                    "summary": "Updated issue",
+                    "description": "",
+                    "priority": {"name": "Low"},
+                    "status": {"name": "Done"},
+                    "issuetype": {"name": "Task"},
+                    "labels": [],
+                    "reporter": {"accountId": "x", "displayName": "X"},
+                },
+            },
+            "changelog": {
+                "items": [
+                    {
+                        "field": "status",
+                        "fromString": "Open",
+                        "toString": "Done",
+                    }
+                ]
+            },
+        }
+        request = _make_request(data)
+
+        with (
+            patch(
+                "python.api.webhook_jira._get_jira_webhook_secret",
+                return_value="test-jira-secret",
+            ),
+            patch(
+                "python.api.webhook_jira.WebhookJira._process_jira_event",
+                new_callable=AsyncMock,
+            ) as mock_process,
+        ):
+            result = await handler.process({}, request)
+
+        assert result == {"ok": True}
+        mock_process.assert_not_called()

--- a/tests/test_webhook_slack.py
+++ b/tests/test_webhook_slack.py
@@ -1,0 +1,260 @@
+# tests/test_webhook_slack.py
+"""Tests for the Slack webhook receiver API handler."""
+
+import hashlib
+import hmac
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_slack_signature(body: bytes, secret: str, timestamp: str) -> str:
+    """Generate a valid Slack signature for testing."""
+    sig_basestring = f"v0:{timestamp}:{body.decode()}".encode()
+    return "v0=" + hmac.new(secret.encode(), sig_basestring, hashlib.sha256).hexdigest()
+
+
+def _make_request(
+    data: dict,
+    secret: str = "test-signing-secret",
+    timestamp: str | None = None,
+) -> MagicMock:
+    """Create a mock Flask Request with Slack headers."""
+    if timestamp is None:
+        timestamp = str(int(time.time()))
+    body = json.dumps(data).encode()
+    sig = _make_slack_signature(body, secret, timestamp)
+    request = MagicMock()
+    request.data = body
+    request.get_json.return_value = data
+    request.headers = {
+        "X-Slack-Signature": sig,
+        "X-Slack-Request-Timestamp": timestamp,
+    }
+    return request
+
+
+class TestSlackWebhookImport:
+    def test_handler_importable(self):
+        from python.api.webhook_slack import WebhookSlack
+
+        assert WebhookSlack is not None
+
+    def test_requires_no_auth(self):
+        from python.api.webhook_slack import WebhookSlack
+
+        assert WebhookSlack.requires_auth() is False
+
+    def test_requires_no_csrf(self):
+        from python.api.webhook_slack import WebhookSlack
+
+        assert WebhookSlack.requires_csrf() is False
+
+    def test_post_only(self):
+        from python.api.webhook_slack import WebhookSlack
+
+        assert WebhookSlack.get_methods() == ["POST"]
+
+
+class TestSlackUrlVerification:
+    @pytest.mark.asyncio
+    async def test_url_verification_returns_challenge(self):
+        from python.api.webhook_slack import WebhookSlack
+
+        handler = WebhookSlack(MagicMock(), MagicMock())
+        data = {"type": "url_verification", "challenge": "abc123"}
+        request = _make_request(data)
+
+        with patch(
+            "python.api.webhook_slack._get_slack_signing_secret",
+            return_value="test-signing-secret",
+        ):
+            result = await handler.process({}, request)
+
+        assert result == {"challenge": "abc123"}
+
+
+class TestSlackSignatureRejection:
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_signature(self):
+        from python.api.webhook_slack import WebhookSlack
+
+        handler = WebhookSlack(MagicMock(), MagicMock())
+        data = {"type": "event_callback", "event": {"type": "app_mention"}}
+        request = _make_request(data, secret="wrong-secret")
+
+        with patch(
+            "python.api.webhook_slack._get_slack_signing_secret",
+            return_value="correct-secret",
+        ):
+            result = await handler.process({}, request)
+
+        # Should return a 403 response
+        assert hasattr(result, "status_code")
+        assert result.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_rejects_stale_timestamp(self):
+        from python.api.webhook_slack import WebhookSlack
+
+        handler = WebhookSlack(MagicMock(), MagicMock())
+        data = {"type": "event_callback", "event": {"type": "app_mention"}}
+        old_ts = str(int(time.time()) - 600)  # 10 minutes ago
+        request = _make_request(data, timestamp=old_ts)
+
+        with patch(
+            "python.api.webhook_slack._get_slack_signing_secret",
+            return_value="test-signing-secret",
+        ):
+            result = await handler.process({}, request)
+
+        assert hasattr(result, "status_code")
+        assert result.status_code == 403
+
+
+class TestSlackEventProcessing:
+    @pytest.mark.asyncio
+    async def test_app_mention_triggers_processing(self):
+        from python.api.webhook_slack import WebhookSlack
+
+        handler = WebhookSlack(MagicMock(), MagicMock())
+        data = {
+            "type": "event_callback",
+            "team_id": "T1234",
+            "event_id": "Ev1234",
+            "event": {
+                "type": "app_mention",
+                "user": "U5678",
+                "text": "<@BOT> help me",
+                "channel": "C9012",
+                "ts": "1234567890.123456",
+                "thread_ts": "1234567890.000000",
+            },
+        }
+        request = _make_request(data)
+
+        with (
+            patch(
+                "python.api.webhook_slack._get_slack_signing_secret",
+                return_value="test-signing-secret",
+            ),
+            patch(
+                "python.api.webhook_slack.WebhookSlack._process_slack_event",
+                new_callable=AsyncMock,
+            ) as mock_process,
+        ):
+            result = await handler.process({}, request)
+
+        assert result == {"ok": True}
+        mock_process.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_dm_message_triggers_processing(self):
+        from python.api.webhook_slack import WebhookSlack
+
+        handler = WebhookSlack(MagicMock(), MagicMock())
+        data = {
+            "type": "event_callback",
+            "team_id": "T1234",
+            "event_id": "Ev5678",
+            "event": {
+                "type": "message",
+                "channel_type": "im",
+                "user": "U5678",
+                "text": "help me",
+                "channel": "D9012",
+                "ts": "1234567890.123456",
+            },
+        }
+        request = _make_request(data)
+
+        with (
+            patch(
+                "python.api.webhook_slack._get_slack_signing_secret",
+                return_value="test-signing-secret",
+            ),
+            patch(
+                "python.api.webhook_slack.WebhookSlack._process_slack_event",
+                new_callable=AsyncMock,
+            ) as mock_process,
+        ):
+            result = await handler.process({}, request)
+
+        assert result == {"ok": True}
+        mock_process.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ignores_bot_messages(self):
+        from python.api.webhook_slack import WebhookSlack
+
+        handler = WebhookSlack(MagicMock(), MagicMock())
+        data = {
+            "type": "event_callback",
+            "team_id": "T1234",
+            "event_id": "Ev9012",
+            "event": {
+                "type": "message",
+                "channel_type": "im",
+                "bot_id": "B1234",
+                "text": "bot message",
+                "channel": "D9012",
+                "ts": "1234567890.123456",
+            },
+        }
+        request = _make_request(data)
+
+        with (
+            patch(
+                "python.api.webhook_slack._get_slack_signing_secret",
+                return_value="test-signing-secret",
+            ),
+            patch(
+                "python.api.webhook_slack.WebhookSlack._process_slack_event",
+                new_callable=AsyncMock,
+            ) as mock_process,
+        ):
+            result = await handler.process({}, request)
+
+        assert result == {"ok": True}
+        mock_process.assert_not_called()
+
+
+class TestSlackEventDedup:
+    @pytest.mark.asyncio
+    async def test_duplicate_event_ignored(self):
+        from python.api.webhook_slack import WebhookSlack, _event_dedup_cache
+
+        _event_dedup_cache.clear()
+        handler = WebhookSlack(MagicMock(), MagicMock())
+        data = {
+            "type": "event_callback",
+            "team_id": "T1234",
+            "event_id": "Ev_DEDUP",
+            "event": {
+                "type": "app_mention",
+                "user": "U5678",
+                "text": "hello",
+                "channel": "C9012",
+                "ts": "111.111",
+            },
+        }
+        request1 = _make_request(data)
+        request2 = _make_request(data)
+
+        with (
+            patch(
+                "python.api.webhook_slack._get_slack_signing_secret",
+                return_value="test-signing-secret",
+            ),
+            patch(
+                "python.api.webhook_slack.WebhookSlack._process_slack_event",
+                new_callable=AsyncMock,
+            ) as mock_process,
+        ):
+            await handler.process({}, request1)
+            await handler.process({}, request2)
+
+        # Should only process once despite two calls
+        mock_process.assert_called_once()

--- a/tests/test_webhook_verify.py
+++ b/tests/test_webhook_verify.py
@@ -1,0 +1,80 @@
+# tests/test_webhook_verify.py
+"""Tests for webhook signature verification helpers."""
+
+import hashlib
+import hmac
+import time
+
+
+class TestGitHubSignature:
+    def test_valid_signature(self):
+        from python.helpers.webhook_verify import verify_github_signature
+
+        secret = "test-secret"
+        body = b'{"action":"opened"}'
+        sig = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+        assert verify_github_signature(body, sig, secret) is True
+
+    def test_invalid_signature(self):
+        from python.helpers.webhook_verify import verify_github_signature
+
+        assert verify_github_signature(b"body", "sha256=bad", "secret") is False
+
+    def test_missing_signature(self):
+        from python.helpers.webhook_verify import verify_github_signature
+
+        assert verify_github_signature(b"body", None, "secret") is False
+
+    def test_wrong_prefix(self):
+        from python.helpers.webhook_verify import verify_github_signature
+
+        assert verify_github_signature(b"body", "sha1=abc", "secret") is False
+
+
+class TestSlackSignature:
+    def test_valid_signature(self):
+        from python.helpers.webhook_verify import verify_slack_signature
+
+        secret = "8f742231b10e8888abcd99yez67543"
+        timestamp = str(int(time.time()))
+        body = b"token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J"
+        sig_basestring = f"v0:{timestamp}:{body.decode()}".encode()
+        sig = (
+            "v0="
+            + hmac.new(secret.encode(), sig_basestring, hashlib.sha256).hexdigest()
+        )
+        assert verify_slack_signature(body, sig, timestamp, secret) is True
+
+    def test_invalid_signature(self):
+        from python.helpers.webhook_verify import verify_slack_signature
+
+        assert verify_slack_signature(b"body", "v0=bad", "123", "secret") is False
+
+    def test_stale_timestamp(self):
+        from python.helpers.webhook_verify import verify_slack_signature
+
+        old_ts = str(int(time.time()) - 600)  # 10 minutes old
+        assert verify_slack_signature(b"body", "v0=sig", old_ts, "secret") is False
+
+    def test_missing_params(self):
+        from python.helpers.webhook_verify import verify_slack_signature
+
+        assert verify_slack_signature(b"body", None, None, "secret") is False
+
+
+class TestJiraSignature:
+    def test_valid_shared_secret(self):
+        from python.helpers.webhook_verify import verify_jira_signature
+
+        secret = "my-jira-secret"
+        assert verify_jira_signature(secret, secret) is True
+
+    def test_invalid_shared_secret(self):
+        from python.helpers.webhook_verify import verify_jira_signature
+
+        assert verify_jira_signature("provided", "expected") is False
+
+    def test_missing_secret(self):
+        from python.helpers.webhook_verify import verify_jira_signature
+
+        assert verify_jira_signature(None, "expected") is False

--- a/usr/.env.example
+++ b/usr/.env.example
@@ -214,6 +214,25 @@
 # A0_SET_RFC_PORT_SSH=55022
 # A0_SET_SHELL_INTERFACE=ssh
 
+# --- Platform Integrations ---
+# Master toggle for inbound webhook processing (Slack, GitHub, Jira).
+# A0_SET_INTEGRATIONS_ENABLED=false
+
+# Slack Bot — signing secret and bot token from your Slack App.
+# See docs/integrations/slack-bot-setup.md for setup instructions.
+# A0_SET_SLACK_SIGNING_SECRET=
+# A0_SET_SLACK_BOT_TOKEN=xoxb-...
+
+# GitHub App — webhook secret and App ID from your GitHub App.
+# See docs/integrations/github-app-setup.md for setup instructions.
+# A0_SET_GITHUB_WEBHOOK_SECRET=
+# A0_SET_GITHUB_APP_ID=
+
+# Jira — webhook shared secret and site URL.
+# See docs/integrations/jira-webhook-setup.md for setup instructions.
+# A0_SET_JIRA_WEBHOOK_SECRET=
+# A0_SET_JIRA_SITE_URL=https://your-org.atlassian.net
+
 # --- MCP & A2A ---
 # A0_SET_MCP_SERVER_ENABLED=false
 # A0_SET_A2A_SERVER_ENABLED=false

--- a/webui/components/settings/integrations/integrations-settings.html
+++ b/webui/components/settings/integrations/integrations-settings.html
@@ -1,0 +1,129 @@
+<html>
+<head>
+  <title>Integrations</title>
+</head>
+
+<body>
+<div x-data>
+  <template x-if="$store.settings">
+    <div>
+      <h3 class="section-title">Platform Integrations</h3>
+      <p class="section-description">Configure webhook integrations for Slack, GitHub, and Jira.</p>
+
+      <!-- Master toggle -->
+      <div class="setting-row">
+        <label class="setting-label">
+          <span>Enable Integrations</span>
+          <small class="setting-hint">Master toggle for all platform integrations</small>
+        </label>
+        <label class="toggle">
+          <input type="checkbox"
+                 x-model="$store.settings.settings.integrations_enabled" />
+          <span class="slider"></span>
+        </label>
+      </div>
+
+      <!-- Slack Section -->
+      <h4 class="subsection-title">Slack</h4>
+
+      <div class="setting-row">
+        <label class="setting-label">
+          <span>Signing Secret</span>
+          <small class="setting-hint">From Slack App > Basic Information > Signing Secret</small>
+        </label>
+        <input type="password"
+               class="setting-input"
+               x-model="$store.settings.settings.slack_signing_secret"
+               placeholder="Enter Slack signing secret" />
+      </div>
+
+      <div class="setting-row">
+        <label class="setting-label">
+          <span>Bot Token</span>
+          <small class="setting-hint">xoxb-* token from Slack App > OAuth & Permissions</small>
+        </label>
+        <input type="password"
+               class="setting-input"
+               x-model="$store.settings.settings.slack_bot_token"
+               placeholder="xoxb-..." />
+      </div>
+
+      <!-- GitHub Section -->
+      <h4 class="subsection-title">GitHub</h4>
+
+      <div class="setting-row">
+        <label class="setting-label">
+          <span>Webhook Secret</span>
+          <small class="setting-hint">From GitHub App > Webhook > Secret</small>
+        </label>
+        <input type="password"
+               class="setting-input"
+               x-model="$store.settings.settings.github_webhook_secret"
+               placeholder="Enter GitHub webhook secret" />
+      </div>
+
+      <div class="setting-row">
+        <label class="setting-label">
+          <span>App ID</span>
+          <small class="setting-hint">From GitHub App > General > App ID</small>
+        </label>
+        <input type="text"
+               class="setting-input"
+               x-model="$store.settings.settings.github_app_id"
+               placeholder="123456" />
+      </div>
+
+      <!-- Jira Section -->
+      <h4 class="subsection-title">Jira</h4>
+
+      <div class="setting-row">
+        <label class="setting-label">
+          <span>Webhook Secret</span>
+          <small class="setting-hint">Shared secret configured in Jira webhook URL</small>
+        </label>
+        <input type="password"
+               class="setting-input"
+               x-model="$store.settings.settings.jira_webhook_secret"
+               placeholder="Enter Jira webhook secret" />
+      </div>
+
+      <div class="setting-row">
+        <label class="setting-label">
+          <span>Site URL</span>
+          <small class="setting-hint">Your Jira Cloud instance URL</small>
+        </label>
+        <input type="text"
+               class="setting-input"
+               x-model="$store.settings.settings.jira_site_url"
+               placeholder="https://yourorg.atlassian.net" />
+      </div>
+    </div>
+  </template>
+</div>
+</body>
+</html>
+
+<style>
+.section-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+  color: var(--color-text-primary, #fff);
+}
+
+.section-description {
+  color: var(--color-text-secondary, #999);
+  font-size: 0.875rem;
+  margin-bottom: 1.5rem;
+}
+
+.subsection-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-top: 1.5rem;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.375rem;
+  border-bottom: 1px solid var(--color-border, #333);
+  color: var(--color-text-primary, #fff);
+}
+</style>

--- a/webui/components/settings/settings.html
+++ b/webui/components/settings/settings.html
@@ -42,13 +42,17 @@
                  :class="{'active': $store.settings.activeTab === 'external'}"
                  @click="$store.settings.switchTab('external')"
                  title="External Services">External Services</div>
-            <div class="settings-tab" 
+            <div class="settings-tab"
+                 :class="{'active': $store.settings.activeTab === 'integrations'}"
+                 @click="$store.settings.switchTab('integrations')"
+                 title="Integrations">Integrations</div>
+            <div class="settings-tab"
                  :class="{'active': $store.settings.activeTab === 'mcp'}"
-                 @click="$store.settings.switchTab('mcp')" 
+                 @click="$store.settings.switchTab('mcp')"
                  title="MCP">MCP/A2A</div>
-            <div class="settings-tab" 
+            <div class="settings-tab"
                  :class="{'active': $store.settings.activeTab === 'developer'}"
-                 @click="$store.settings.switchTab('developer')" 
+                 @click="$store.settings.switchTab('developer')"
                  title="Developer">Developer</div>
             <div class="settings-tab"
                  :class="{'active': $store.settings.activeTab === 'backup'}"
@@ -64,6 +68,9 @@
           </div>
           <div x-show="$store.settings.activeTab === 'external'">
             <x-component path="settings/external/external-settings.html"></x-component>
+          </div>
+          <div x-show="$store.settings.activeTab === 'integrations'">
+            <x-component path="settings/integrations/integrations-settings.html"></x-component>
           </div>
           <div x-show="$store.settings.activeTab === 'mcp'">
             <x-component path="settings/mcp/mcp-settings.html"></x-component>
@@ -82,12 +89,12 @@
 
       <!-- Footer -->
       <div class="modal-footer" data-modal-footer x-show="$store.settings.settings">
-        <button class="btn btn-ok" 
+        <button class="btn btn-ok"
             @click="$store.settings.saveAndClose()"
             :disabled="$store.settings?.isLoading">
         Save
         </button>
-        <button class="btn btn-cancel" 
+        <button class="btn btn-cancel"
                 @click="$store.settings.closeSettings()">
           Cancel
         </button>


### PR DESCRIPTION
## Summary

- Adds complete platform integration framework for Slack, GitHub, and Jira using a webhook-inbound + MCP-outbound architecture
- Thin webhook receivers accept inbound events, verify signatures, normalize payloads into `IntegrationMessage` models, and register callbacks for response delivery
- `monologue_end` extension fires callbacks when the agent completes, routing to platform-specific delivery methods
- Includes external identity linking (OAuth), integration settings UI, retry/DLQ, event logging, and human-in-the-loop plan approval

### Phase 1: Foundation (7 commits)
- `IntegrationMessage`, `WebhookContext`, `CallbackRegistration` Pydantic models with `SourceType` enum
- HMAC-SHA256 signature verification for GitHub/Slack, shared-secret for Jira
- Thread-safe in-memory `CallbackRegistry` singleton
- `_80_integration_callback` monologue_end extension with platform routing
- `ExternalIdentity` SQLAlchemy model + Alembic migration for identity linking
- Integration settings fields in `Settings` TypedDict with `A0_SET_` env var overrides
- Per-platform prompt templates (`prompts/integrations/`)

### Phase 2: Slack (3 commits)
- `POST /webhook_slack` — Events API receiver with dedup cache and bot-message filtering
- Slack callback delivery routing in the extension
- `GET /webhook_slack_oauth` — OAuth2 identity linking handler

### Phase 3: GitHub (3 commits)
- `POST /webhook_github` — GitHub App webhook receiver (issues, PRs, comments)
- GitHub callback delivery routing tests
- GitHub App setup documentation (`docs/integrations/github-app-setup.md`)

### Phase 4: Jira (3 commits)
- `POST /webhook_jira` — Jira Cloud webhook receiver (issue created/updated, comments)
- Jira callback delivery routing tests
- `python/helpers/jira_markup.py` — Markdown-to-Jira wiki markup converter

### Phase 5: Enhanced Features (5 commits)
- `AWAITING_APPROVAL` status for human-in-the-loop plan approval workflow
- `GET /integration_settings_get` API + Integrations tab in Settings UI
- `AGENTS.md` for cross-framework AI agent compatibility
- `python/helpers/callback_retry.py` + `POST /callback_admin` — retry with exponential backoff (max 3 attempts)
- `python/helpers/webhook_event_log.py` + `GET /webhook_events_get` — bounded in-memory event log

## Test plan

- [x] 140 new tests added (749 baseline → 889 total), all passing
- [x] All pre-commit hooks passing (Ruff lint/format, conventional commits, security checks)
- [x] TDD workflow: red phase (failing tests) → green phase (implementation) → commit per task
- [ ] Manual: Configure Slack App webhook URL → verify signature validation → confirm event processing
- [ ] Manual: Create GitHub App → install on repo → open issue → verify webhook fires
- [ ] Manual: Configure Jira webhook → create issue → verify event processing
- [ ] Manual: Verify Settings UI Integrations tab renders correctly with all fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)